### PR TITLE
New structural application elements

### DIFF
--- a/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
+++ b/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
@@ -85,20 +85,8 @@
     </CLaw>
 
     <!--constitutive laws for trusses-->
-    <CLaw n="ConstitutiveLaw3D" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics"
-          help="Linear elastic behaviour for 3D trusses" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
-        <inputs>
-            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
-            <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
-            <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-            <parameter n="CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2"  />
-        </inputs>
-        <outputs>
-
-        </outputs>
-    </CLaw>
-    <CLaw n="ConstitutiveLaw2D" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics"
-          help="Linear elastic behaviour for 2D trusses" Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
+    <CLaw n="ConstitutiveLaw" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics"
+          help="Linear elastic behaviour for trusses" Dimension="2D,3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />

--- a/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
+++ b/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
@@ -46,17 +46,6 @@
 
         </outputs>
     </CLaw>
-    <CLaw n="LinearElasticBeamLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="1D" behaviour="Elastic" StrainSize="6"  ImplementedInApplication="StructuralMechanicsApplication"
-	  help="Linear elastic behaviour in 3D for beams" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="D-R" AllowsAnisotropy="False" >
-        <inputs>
-            <parameter n="DENSITY" pn="Density"/>
-            <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
-            <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-        </inputs>
-        <outputs>
-
-        </outputs>
-    </CLaw>
 
     <!--constitutive laws for shells and membranes-->
     <CLaw n="LinearElasticPlaneStress2DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="PlaneStress" behaviour="Elastic" StrainSize="6"  ImplementedInApplication="StructuralMechanicsApplication"
@@ -90,9 +79,19 @@
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-            <parameter n="CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2" />
+            <parameter n="KratosMultiphysics.StructuralMechanicsApplication.CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2" />
         </inputs>
         <outputs></outputs>
     </CLaw>
 
+    <!--constitutive laws for beams-->
+    <CLaw n="BeamConstitutiveLaw" pn="Linear elastic beam" ProductionReady="ProductionReady" Type="Beam" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics" help="Linear elastic behaviour for beams" Dimension="2D,3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False">
+        <inputs>
+            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
+            <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
+            <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
+            <parameter n="KratosMultiphysics.StructuralMechanicsApplication.CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2" />
+        </inputs>
+        <outputs></outputs>
+    </CLaw>
 </ConstitutiveLaws>

--- a/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
+++ b/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
@@ -85,17 +85,14 @@
     </CLaw>
 
     <!--constitutive laws for trusses-->
-    <CLaw n="ConstitutiveLaw" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics"
-          help="Linear elastic behaviour for trusses" Dimension="2D,3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
+    <CLaw n="TrussConstitutiveLaw" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics" help="Linear elastic behaviour for trusses" Dimension="2D,3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False">
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-            <parameter n="CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2"  />
+            <parameter n="CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2" />
         </inputs>
-        <outputs>
-
-        </outputs>
+        <outputs></outputs>
     </CLaw>
 
 </ConstitutiveLaws>

--- a/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
+++ b/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
@@ -84,4 +84,17 @@
         </outputs>
     </CLaw>
     
+    <CLaw n="ConstitutiveLaw" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics"
+          help="Linear elastic for Truss" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
+        <inputs>
+            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
+            <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
+            <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
+            <parameter n="CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2"  />  
+        </inputs>
+        <outputs>
+            
+        </outputs>
+    </CLaw>
+    
 </ConstitutiveLaws>

--- a/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
+++ b/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
@@ -2,99 +2,112 @@
 <ConstitutiveLaws>
     <!--linear elastic laws-->
     <CLaw n="LinearElastic3DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="3D" behaviour="Elastic" StrainSize="6"  ImplementedInApplication="StructuralMechanicsApplication"
-	  help="Linear Elastic Behaviour in 3D" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" AllowsAnisotropy="False" >
+	  help="Linear elastic behaviour in 3D" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" AllowsAnisotropy="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
         </inputs>
         <outputs>
-            
+
         </outputs>
     </CLaw>
     <CLaw n="LinearElasticPlaneStrain2DLaw" pn="Linear Elastic Plane Strain" ProductionReady="ProductionReady" Type="PlaneStrain" behaviour="Elastic" StrainSize="3" ImplementedInApplication="StructuralMechanicsApplication"
-          help="Linear Elastic Behaviour in 2D Plane Strain" Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
+          help="Linear elastic behaviour in 2D plane strain" Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
         </inputs>
         <outputs>
-            
+
         </outputs>
     </CLaw>
     <CLaw n="LinearElasticPlaneStress2DLaw" pn="Linear Elastic Plane Stress" ProductionReady="ProductionReady" Type="PlaneStress" behaviour="Elastic" StrainSize="3" ImplementedInApplication="StructuralMechanicsApplication"
-          help="Linear Elastic Behaviour in 2D Plane Stress" Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
+          help="Linear elastic behaviour in 2D plane stress" Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-            <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m"  />  
+            <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m"  />
         </inputs>
         <outputs>
-            
+
         </outputs>
     </CLaw>
     <CLaw n="LinearElasticAxisym2DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="Axisymmetric" behaviour="Elastic" StrainSize="4" ImplementedInApplication="StructuralMechanicsApplication"
-          help="Linear Elastic Behaviour in 2D Axisymmetric" Dimension="2Da" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
+          help="Linear elastic behaviour in 2D axisymmetric" Dimension="2Da" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
         </inputs>
         <outputs>
-            
+
         </outputs>
     </CLaw>
     <CLaw n="LinearElasticBeamLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="1D" behaviour="Elastic" StrainSize="6"  ImplementedInApplication="StructuralMechanicsApplication"
-	  help="Linear Elastic Behaviour in 3D for Beams" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="D-R" AllowsAnisotropy="False" >
+	  help="Linear elastic behaviour in 3D for beams" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="D-R" AllowsAnisotropy="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
         </inputs>
         <outputs>
-            
+
         </outputs>
     </CLaw>
-    
+
     <!--constitutive laws for shells and membranes-->
     <CLaw n="LinearElasticPlaneStress2DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="PlaneStress" behaviour="Elastic" StrainSize="6"  ImplementedInApplication="StructuralMechanicsApplication"
-	  help="Linear Elastic Behaviour in 3D for Shells" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="D-R" AllowsAnisotropy="False" >
+	  help="Linear elastic behaviour in 3D for shells" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="D-R" AllowsAnisotropy="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-            <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m"  />  
+            <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m"  />
         </inputs>
         <outputs>
-            
+
         </outputs>
     </CLaw>
     <CLaw n="LinearElasticPlaneStress2DLaw" pn="Linear Elastic Plane Stress" ProductionReady="ProductionReady" Type="PlaneStress" behaviour="Elastic" StrainSize="3" ImplementedInApplication="StructuralMechanicsApplication"
-          help="Linear Elastic Behaviour in 2D Plane Stress" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
+          help="Linear elastic behaviour in 2D plane stress" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-            <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m"  />  
+            <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m"  />
         </inputs>
         <outputs>
-            
+
         </outputs>
     </CLaw>
-    
-    <CLaw n="ConstitutiveLaw" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics"
-          help="Linear elastic for Truss" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
+
+    <!--constitutive laws for trusses-->
+    <CLaw n="ConstitutiveLaw3D" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics"
+          help="Linear elastic behaviour for 3D trusses" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-            <parameter n="CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2"  />  
+            <parameter n="CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2"  />
         </inputs>
         <outputs>
-            
+
         </outputs>
     </CLaw>
-    
+    <CLaw n="ConstitutiveLaw2D" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="KratosMultiphysics"
+          help="Linear elastic behaviour for 2D trusses" Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
+        <inputs>
+            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
+            <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
+            <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
+            <parameter n="CROSS_AREA" pn="Cross area" v="1.0" unit_magnitude="Area" units="m^2"  />
+        </inputs>
+        <outputs>
+
+        </outputs>
+    </CLaw>
+
 </ConstitutiveLaws>

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -481,7 +481,7 @@
                help="This element implements a quadrilateral corotational element for thin shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
-      <item GeometryType="Quadrilateral" nodes="4" KratosName="QuadShellThinElementCorotational3D4N"/>
+      <item GeometryType="Quadrilateral" nodes="4" KratosName="ShellThinElementCorotational3D4N"/>
     </TopologyFeatures>
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -2,7 +2,9 @@
 <ElementList>
   <!--solid elements-->
   <!--small displacements-->
-  <ElementItem n="SmallDisplacementElement2D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement solid element">
+  <ElementItem n="SmallDisplacementElement2D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+               help="This element it implements a small displacement solid element">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="SmallDisplacementElement2D3N"/>
@@ -37,7 +39,10 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="SmallDisplacementElementAxisym" pn="Solid small displacements" ImplementedInFile="axisym_small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2Da" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements an axisymetric small displacement solid element">
+
+  <ElementItem n="SmallDisplacementElementAxisym" pn="Solid small displacements" ImplementedInFile="axisym_small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2Da" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+               help="This element it implements an axisymetric small displacement solid element">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="AxisymSmallDisplacementElement2D3N"/>
@@ -69,7 +74,10 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="SmallDisplacementElement3D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement solid element">
+
+  <ElementItem n="SmallDisplacementElement3D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+               help="This element it implements a small displacement solid element">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Tetrahedra" nodes="4" KratosName="SmallDisplacementElement3D4N"/>
@@ -104,9 +112,12 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
+
   <!--large displacements-->
   <!--total lagrangian-->
-  <ElementItem n="TotalLagrangianElement2D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" help="This element it implements a Total Lagrangian approach to large deformation kinematics">
+  <ElementItem n="TotalLagrangianElement2D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" 
+               help="This element it implements a Total Lagrangian approach to large deformation kinematics">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="TotalLagrangianElement2D3N"/>
@@ -138,7 +149,10 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="TotalLagrangianElement3D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a Total Lagrangian approach to large deformation kinematics">
+
+  <ElementItem n="TotalLagrangianElement3D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+               help="This element it implements a Total Lagrangian approach to large deformation kinematics">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Tetrahedra" nodes="4" KratosName="TotalLagrangianElement3D4N"/>
@@ -172,8 +186,11 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
+
   <!--updated lagrangian-->
-  <ElementItem n="UpdatedLagrangianElement2D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" help="This element it implements a Updated Lagrangian approach to large deformation kinematics">
+  <ElementItem n="UpdatedLagrangianElement2D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" 
+               help="This element it implements a Updated Lagrangian approach to large deformation kinematics">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="UpdatedLagrangianElement2D3N"/>
@@ -205,7 +222,10 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="UpdatedLagrangianElement3D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a Updated Lagrangian approach to large deformation kinematics">
+
+  <ElementItem n="UpdatedLagrangianElement3D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+               help="This element it implements a Updated Lagrangian approach to large deformation kinematics">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Tetrahedra" nodes="4" KratosName="UpdatedLagrangianElement3D4N"/>
@@ -239,9 +259,13 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
+
   <!--structural elements-->
   <!--beam elements-->
-  <ElementItem n="BeamElement" pn="Small displacements beam" ImplementedInFile="small_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="True" LocalAxesAutomaticFunction="Structural::xml::AddLocalAxesToBeamElement" LargeDeformation="False" help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam">
+  <ElementItem n="BeamElement" pn="Small displacements beam" ImplementedInFile="small_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="True" 
+               LocalAxesAutomaticFunction="Structural::xml::AddLocalAxesToBeamElement" LargeDeformation="False" 
+               help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="SmallDisplacementBeamElement3D2N"/>
@@ -271,8 +295,11 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
     </outputs>
   </ElementItem>
+
   <!--truss elements-->
-  <ElementItem n="TrussElement3D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss">
+  <ElementItem n="TrussElement3D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" 
+               help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="TrussElement3D2N"/>
@@ -296,7 +323,10 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="TrussElement2D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss">
+
+  <ElementItem n="TrussElement2D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" 
+               help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="TrussElement3D2N"/>
@@ -320,8 +350,11 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
     </outputs>
   </ElementItem>
+
   <!--membrane elements-->
-  <ElementItem n="MembraneElement" pn="Membrane" ImplementedInFile="membrane_element.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" help="This element it implements a membrane structural model" RotationDofs="False" ElementType="Membrane">
+  <ElementItem n="MembraneElement" pn="Membrane" ImplementedInFile="membrane_element.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" 
+               help="This element it implements a membrane structural model" RotationDofs="False" ElementType="Membrane">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="MembraneElement3D3N"/>
@@ -346,9 +379,12 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
     </outputs>
   </ElementItem>
+
   <!--shell elements-->
   <!--small displacements-->
-  <ElementItem n="ShellThinElement" pn="Thin triangular shell" ImplementedInFile="shell_thin_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="False" help="This element implements a triangular element for thin shells in a small displacements approach" ElementType="Shell" RotationDofs="True">
+  <ElementItem n="TriShellThinElement" pn="Thin triangular shell" ImplementedInFile="shell_thin_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="False" 
+               help="This element implements a triangular element for thin shells in a small displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="ShellThinElement3D3N"/>
@@ -376,7 +412,10 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
     </outputs>
   </ElementItem>
-  <ElementItem n="ShellThickElement" pn="Thick quadrilateral shell" ImplementedInFile="shell_thick_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="False" help="This element implements a quadrilateral element for thick shells in a small displacements approach" ElementType="Shell" RotationDofs="True">
+
+  <ElementItem n="QuadShellThickElement" pn="Thick quadrilateral shell" ImplementedInFile="shell_thick_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="False" 
+               help="This element implements a quadrilateral element for thick shells in a small displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Quadrilateral" nodes="4" KratosName="ShellThickElement3D4N"/>
@@ -404,8 +443,11 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
     </outputs>
   </ElementItem>
+
   <!--large displacements-->
-  <ElementItem n="ShellThinCorotationalElement" pn="Thin corotational triangular shell" ImplementedInFile="shell_thin_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" help="This element implements a triangular corotational element for thin shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
+  <ElementItem n="TriShellThinCorotationalElement" pn="Thin corotational triangular shell" ImplementedInFile="shell_thin_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" 
+               help="This element implements a triangular corotational element for thin shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="ShellThinElementCorotational3D3N"/>
@@ -433,7 +475,72 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
     </outputs>
   </ElementItem>
-  <ElementItem n="ShellThickCorotationalElement" pn="Thick corotational quadrilateral shell" ImplementedInFile="shell_thick_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" help="This element implements a quadrilateral corotational element for thick shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
+
+  <ElementItem n="QuadShellThinCorotationalElement" pn="Thin corotational quadrilateral shell" ImplementedInFile="shell_thin_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" 
+               help="This element implements a quadrilateral corotational element for thin shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
+    <!--here we could add a list of all of the possible geometries-->
+    <TopologyFeatures>
+      <item GeometryType="Quadrilateral" nodes="4" KratosName="QuadShellThinElementCorotational3D4N"/>
+    </TopologyFeatures>
+    <!-- here we add the block of features which we require from the constitutive law-->
+    <ConstitutiveLaw_FilterFeatures>
+      <filter field="Type" value="PlaneStress"/>
+      <filter field="Dimension" value="3D"/>
+      <filter field="StrainSize" value="6"/>
+      <filter field="HybridType" value="D-R"/>
+    </ConstitutiveLaw_FilterFeatures>
+    <!--define list of NodalConditions-->
+    <NodalConditions>
+      <NodalCondition n="DISPLACEMENT"/>
+      <NodalCondition n="ROTATION"/>
+      <NodalCondition n="VELOCITY"/>
+      <NodalCondition n="ACCELERATION" />
+      <NodalCondition n="ANGULAR_VELOCITY"/>
+      <NodalCondition n="ANGULAR_ACCELERATION"/>
+    </NodalConditions>
+    <inputs>
+      <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m" />
+    </inputs>
+    <outputs>
+      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
+    </outputs>
+  </ElementItem>
+
+  <ElementItem n="TriShellThickCorotationalElement" pn="Thick corotational triangular shell" ImplementedInFile="shell_thick_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" 
+               help="This element implements a triangular corotational element for thick shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
+    <!--here we could add a list of all of the possible geometries-->
+    <TopologyFeatures>
+      <item GeometryType="Triangle" nodes="3" KratosName="ShellThickElementCorotational3D3N"/>
+    </TopologyFeatures>
+    <!-- here we add the block of features which we require from the constitutive law-->
+    <ConstitutiveLaw_FilterFeatures>
+      <filter field="Type" value="PlaneStress"/>
+      <filter field="Dimension" value="3D"/>
+      <filter field="StrainSize" value="6"/>
+      <filter field="HybridType" value="D-R"/>
+    </ConstitutiveLaw_FilterFeatures>
+    <!--define list of NodalConditions-->
+    <NodalConditions>
+      <NodalCondition n="DISPLACEMENT" />
+      <NodalCondition n="ROTATION" />
+      <NodalCondition n="VELOCITY" />
+      <NodalCondition n="ACCELERATION" />
+      <NodalCondition n="ANGULAR_VELOCITY"/>
+      <NodalCondition n="ANGULAR_ACCELERATION" />
+    </NodalConditions>
+    <inputs>
+      <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m" />
+    </inputs>
+    <outputs>
+      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
+    </outputs>
+  </ElementItem>
+  
+  <ElementItem n="QuadShellThickCorotationalElement" pn="Thick corotational quadrilateral shell" ImplementedInFile="shell_thick_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" 
+               help="This element implements a quadrilateral corotational element for thick shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Quadrilateral" nodes="4" KratosName="ShellThickElementCorotational3D4N"/>

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -271,6 +271,55 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
     </outputs>
   </ElementItem>
+  <!--truss elements-->
+  <ElementItem n="TrussElement3D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss">
+    <!--here we could add a list of all of the possible geometries-->
+    <TopologyFeatures>
+      <item GeometryType="Line" nodes="2" KratosName="TrussElement3D2N"/>
+    </TopologyFeatures>
+    <!-- here we add the block of features which we require from the constitutive law-->
+    <ConstitutiveLaw_FilterFeatures>
+      <filter field="Type" value="Truss"/>
+      <filter field="Dimension" value="3D"/>
+      <filter field="StrainSize" value="1"/>
+    </ConstitutiveLaw_FilterFeatures>
+    <!--define list of NodalConditions-->
+    <NodalConditions>
+      <NodalCondition n="DISPLACEMENT"/>
+      <NodalCondition n="VELOCITY"/>
+      <NodalCondition n="ACCELERATION"/>
+    </NodalConditions>
+    <inputs>
+     </inputs>
+    <outputs>
+      <parameter n="GREEN_LAGRANGE_STRAIN_TENSOR" pn="Green-Lagrange strain tensor" />
+      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
+    </outputs>
+  </ElementItem>
+  <ElementItem n="TrussElement2D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss">
+    <!--here we could add a list of all of the possible geometries-->
+    <TopologyFeatures>
+      <item GeometryType="Line" nodes="2" KratosName="TrussElement3D2N"/>
+    </TopologyFeatures>
+    <!-- here we add the block of features which we require from the constitutive law-->
+    <ConstitutiveLaw_FilterFeatures>
+      <filter field="Type" value="Truss"/>
+      <filter field="Dimension" value="3D"/>
+      <filter field="StrainSize" value="1"/>
+    </ConstitutiveLaw_FilterFeatures>
+    <!--define list of NodalConditions-->
+    <NodalConditions>
+      <NodalCondition n="DISPLACEMENT"/>
+      <NodalCondition n="VELOCITY"/>
+      <NodalCondition n="ACCELERATION"/>
+    </NodalConditions>
+    <inputs>
+    </inputs>
+    <outputs>
+      <parameter n="GREEN_LAGRANGE_STRAIN_TENSOR" pn="Green-Lagrange strain tensor" />
+      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
+    </outputs>
+  </ElementItem>
   <!--membrane elements-->
   <ElementItem n="MembraneElement" pn="Membrane" ImplementedInFile="membrane_element.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" help="This element it implements a membrane structural model" RotationDofs="False" ElementType="Membrane">
     <!--here we could add a list of all of the possible geometries-->

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -262,39 +262,6 @@
 
   <!--structural elements-->
   <!--beam elements-->
-  <!--<ElementItem n="BeamElement" pn="Small displacements beam" ImplementedInFile="small_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="True" 
-               LocalAxesAutomaticFunction="Structural::xml::AddLocalAxesToBeamElement" LargeDeformation="False" 
-               help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam">
-    <!--here we could add a list of all of the possible geometries-->
-    <!--<TopologyFeatures>
-      <item GeometryType="Line" nodes="2" KratosName="SmallDisplacementBeamElement3D2N"/>
-    </TopologyFeatures>
-    <!-- here we add the block of features which we require from the constitutive law-->
-    <!--<ConstitutiveLaw_FilterFeatures>
-      <filter field="Type" value="1D"/>
-      <filter field="Dimension" value="3D"/>
-      <filter field="StrainSize" value="6"/>
-      <filter field="HybridType" value="D-R"/>
-    </ConstitutiveLaw_FilterFeatures>
-    <!--define list of NodalConditions-->
-    <!--<NodalConditions>
-      <NodalCondition n="DISPLACEMENT"/>
-      <NodalCondition n="ROTATION"/>
-      <NodalCondition n="VELOCITY"/>
-      <NodalCondition n="ACCELERATION"/>
-      <NodalCondition n="ANGULAR_VELOCITY"/>
-      <NodalCondition n="ANGULAR_ACCELERATION"/>
-    </NodalConditions>
-    <inputs>
-      <parameter n="LOCAL_AXIS_ROTATION" pn="Local axis rotation" v="0" units="rad" unit_magnitude="Angle" update_proc="ChangeOrientation" command_button="DrawMyLocalAxis"/>
-      <parameter n="SECTION_TYPE" pn="Section type" v="none" type="combo" values="none"/>
-    </inputs>
-    <outputs>
-      <parameter n="GREEN_LAGRANGE_STRAIN_TENSOR" pn="Green-Lagrange strain tensor" />
-      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
-    </outputs>
-  </ElementItem>
 
   <!--truss elements-->
   <ElementItem n="TrussElement3D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -2,8 +2,8 @@
 <ElementList>
   <!--solid elements-->
   <!--small displacements-->
-  <ElementItem n="SmallDisplacementElement2D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+  <ElementItem n="SmallDisplacementElement2D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid"
                help="This element it implements a small displacement solid element">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -40,8 +40,8 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="SmallDisplacementElementAxisym" pn="Solid small displacements" ImplementedInFile="axisym_small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2Da" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+  <ElementItem n="SmallDisplacementElementAxisym" pn="Solid small displacements" ImplementedInFile="axisym_small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2Da" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid"
                help="This element it implements an axisymetric small displacement solid element">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -75,8 +75,8 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="SmallDisplacementElement3D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+  <ElementItem n="SmallDisplacementElement3D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid"
                help="This element it implements a small displacement solid element">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -115,8 +115,8 @@
 
   <!--large displacements-->
   <!--total lagrangian-->
-  <ElementItem n="TotalLagrangianElement2D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" 
+  <ElementItem n="TotalLagrangianElement2D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid"
                help="This element it implements a Total Lagrangian approach to large deformation kinematics">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -150,8 +150,8 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="TotalLagrangianElement3D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+  <ElementItem n="TotalLagrangianElement3D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid"
                help="This element it implements a Total Lagrangian approach to large deformation kinematics">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -188,8 +188,8 @@
   </ElementItem>
 
   <!--updated lagrangian-->
-  <ElementItem n="UpdatedLagrangianElement2D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" 
+  <ElementItem n="UpdatedLagrangianElement2D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid"
                help="This element it implements a Updated Lagrangian approach to large deformation kinematics">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -223,8 +223,8 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="UpdatedLagrangianElement3D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" 
+  <ElementItem n="UpdatedLagrangianElement3D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid"
                help="This element it implements a Updated Lagrangian approach to large deformation kinematics">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -264,8 +264,8 @@
   <!--beam elements-->
 
   <!--truss elements-->
-  <ElementItem n="TrussElement3D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" 
+  <ElementItem n="TrussElement3D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True"
                help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -291,8 +291,8 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="TrussElement2D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" 
+  <ElementItem n="TrussElement2D2N" pn="Large displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True"
                help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -301,7 +301,7 @@
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
       <filter field="Type" value="Truss"/>
-      <filter field="Dimension" value="3D"/>
+      <filter field="Dimension" value="2D"/>
       <filter field="StrainSize" value="1"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
@@ -345,7 +345,7 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="TrussLinearElement3D2N" pn="Small displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+  <ElementItem n="TrussLinearElement2D2N" pn="Small displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
                MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False"
                help="This element implements a small displacements truss" RotationDofs="False" ElementType="Truss">
     <!--here we could add a list of all of the possible geometries-->
@@ -355,7 +355,7 @@
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
       <filter field="Type" value="Truss"/>
-      <filter field="Dimension" value="3D"/>
+      <filter field="Dimension" value="2D"/>
       <filter field="StrainSize" value="1"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
@@ -403,8 +403,8 @@
 
   <!--shell elements-->
   <!--small displacements-->
-  <ElementItem n="TriShellThinElement" pn="Thin triangular shell" ImplementedInFile="shell_thin_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="False" 
+  <ElementItem n="TriShellThinElement" pn="Thin triangular shell" ImplementedInFile="shell_thin_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="False"
                help="This element implements a triangular element for thin shells in a small displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -434,8 +434,8 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="QuadShellThickElement" pn="Thick quadrilateral shell" ImplementedInFile="shell_thick_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="False" 
+  <ElementItem n="QuadShellThickElement" pn="Thick quadrilateral shell" ImplementedInFile="shell_thick_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="False"
                help="This element implements a quadrilateral element for thick shells in a small displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -466,8 +466,8 @@
   </ElementItem>
 
   <!--large displacements-->
-  <ElementItem n="TriShellThinCorotationalElement" pn="Thin corotational triangular shell" ImplementedInFile="shell_thin_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" 
+  <ElementItem n="TriShellThinCorotationalElement" pn="Thin corotational triangular shell" ImplementedInFile="shell_thin_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True"
                help="This element implements a triangular corotational element for thin shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -497,8 +497,8 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="QuadShellThinCorotationalElement" pn="Thin corotational quadrilateral shell" ImplementedInFile="shell_thin_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" 
+  <ElementItem n="QuadShellThinCorotationalElement" pn="Thin corotational quadrilateral shell" ImplementedInFile="shell_thin_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True"
                help="This element implements a quadrilateral corotational element for thin shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -528,8 +528,8 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="TriShellThickCorotationalElement" pn="Thick corotational triangular shell" ImplementedInFile="shell_thick_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" 
+  <ElementItem n="TriShellThickCorotationalElement" pn="Thick corotational triangular shell" ImplementedInFile="shell_thick_element_3D3N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True"
                help="This element implements a triangular corotational element for thick shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
@@ -558,9 +558,9 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
     </outputs>
   </ElementItem>
-  
-  <ElementItem n="QuadShellThickCorotationalElement" pn="Thick corotational quadrilateral shell" ImplementedInFile="shell_thick_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" 
+
+  <ElementItem n="QuadShellThickCorotationalElement" pn="Thick corotational quadrilateral shell" ImplementedInFile="shell_thick_element_3D4N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True"
                help="This element implements a quadrilateral corotational element for thick shells in a large displacements approach" ElementType="Shell" RotationDofs="True">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -318,9 +318,63 @@
     </outputs>
   </ElementItem>
 
+  <ElementItem n="TrussLinearElement3D2N" pn="Small displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False"
+               help="This element implements a small displacements truss" RotationDofs="False" ElementType="Truss">
+    <!--here we could add a list of all of the possible geometries-->
+    <TopologyFeatures>
+      <item GeometryType="Line" nodes="2" KratosName="TrussLinearElement3D2N"/>
+    </TopologyFeatures>
+    <!-- here we add the block of features which we require from the constitutive law-->
+    <ConstitutiveLaw_FilterFeatures>
+      <filter field="Type" value="Truss"/>
+      <filter field="Dimension" value="3D"/>
+      <filter field="StrainSize" value="1"/>
+    </ConstitutiveLaw_FilterFeatures>
+    <!--define list of NodalConditions-->
+    <NodalConditions>
+      <NodalCondition n="DISPLACEMENT"/>
+      <NodalCondition n="VELOCITY"/>
+      <NodalCondition n="ACCELERATION"/>
+    </NodalConditions>
+    <inputs>
+     </inputs>
+    <outputs>
+      <parameter n="GREEN_LAGRANGE_STRAIN_TENSOR" pn="Green-Lagrange strain tensor" />
+      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
+    </outputs>
+  </ElementItem>
+
+  <ElementItem n="TrussLinearElement3D2N" pn="Small displacements truss" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False"
+               help="This element implements a small displacements truss" RotationDofs="False" ElementType="Truss">
+    <!--here we could add a list of all of the possible geometries-->
+    <TopologyFeatures>
+      <item GeometryType="Line" nodes="2" KratosName="TrussLinearElement3D2N"/>
+    </TopologyFeatures>
+    <!-- here we add the block of features which we require from the constitutive law-->
+    <ConstitutiveLaw_FilterFeatures>
+      <filter field="Type" value="Truss"/>
+      <filter field="Dimension" value="3D"/>
+      <filter field="StrainSize" value="1"/>
+    </ConstitutiveLaw_FilterFeatures>
+    <!--define list of NodalConditions-->
+    <NodalConditions>
+      <NodalCondition n="DISPLACEMENT"/>
+      <NodalCondition n="VELOCITY"/>
+      <NodalCondition n="ACCELERATION"/>
+    </NodalConditions>
+    <inputs>
+    </inputs>
+    <outputs>
+      <parameter n="GREEN_LAGRANGE_STRAIN_TENSOR" pn="Green-Lagrange strain tensor" />
+      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
+    </outputs>
+  </ElementItem>
+
   <!--membrane elements-->
-  <ElementItem n="MembraneElement" pn="Membrane" ImplementedInFile="membrane_element.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
-               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" 
+  <ElementItem n="MembraneElement" pn="Membrane" ImplementedInFile="membrane_element.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False"
                help="This element it implements a membrane structural model" RotationDofs="False" ElementType="Membrane">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -262,23 +262,23 @@
 
   <!--structural elements-->
   <!--beam elements-->
-  <ElementItem n="BeamElement" pn="Small displacements beam" ImplementedInFile="small_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
+  <!--<ElementItem n="BeamElement" pn="Small displacements beam" ImplementedInFile="small_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" 
                MinimumKratosVersion="9000" ProductionReady="Developer" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="True" 
                LocalAxesAutomaticFunction="Structural::xml::AddLocalAxesToBeamElement" LargeDeformation="False" 
                help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam">
     <!--here we could add a list of all of the possible geometries-->
-    <TopologyFeatures>
+    <!--<TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="SmallDisplacementBeamElement3D2N"/>
     </TopologyFeatures>
     <!-- here we add the block of features which we require from the constitutive law-->
-    <ConstitutiveLaw_FilterFeatures>
+    <!--<ConstitutiveLaw_FilterFeatures>
       <filter field="Type" value="1D"/>
       <filter field="Dimension" value="3D"/>
       <filter field="StrainSize" value="6"/>
       <filter field="HybridType" value="D-R"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
-    <NodalConditions>
+    <!--<NodalConditions>
       <NodalCondition n="DISPLACEMENT"/>
       <NodalCondition n="ROTATION"/>
       <NodalCondition n="VELOCITY"/>

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -274,7 +274,6 @@
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
       <filter field="Type" value="Truss"/>
-      <filter field="Dimension" value="3D"/>
       <filter field="StrainSize" value="1"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
@@ -301,7 +300,6 @@
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
       <filter field="Type" value="Truss"/>
-      <filter field="Dimension" value="2D"/>
       <filter field="StrainSize" value="1"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
@@ -328,7 +326,6 @@
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
       <filter field="Type" value="Truss"/>
-      <filter field="Dimension" value="3D"/>
       <filter field="StrainSize" value="1"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
@@ -355,7 +352,6 @@
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
       <filter field="Type" value="Truss"/>
-      <filter field="Dimension" value="2D"/>
       <filter field="StrainSize" value="1"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->

--- a/kratos.gid/apps/Structural/xml/Strategies.xml
+++ b/kratos.gid/apps/Structural/xml/Strategies.xml
@@ -23,14 +23,12 @@
             <scheme n="newmark" pn="Newmark" help="Newmark scheme for dynamic problems." ProductionReady="ProductionReady">
                 <parameter_list></parameter_list>
                 <element_filters>
-                    <filter field="ElementType" value="Solid,Shell,Beam"/>
                     <filter field="ImplementedInApplication" value="StructuralMechanicsApplication"/>
                 </element_filters>
             </scheme>
             <scheme n="bossak" pn="Bossak" help="Bossak scheme for dynamic problems with high frequency accelerations damping." ProductionReady="ProductionReady">
                 <parameter_list></parameter_list>
                 <element_filters>
-                    <filter field="ElementType" value="Solid,Shell,Beam"/>
                     <filter field="ImplementedInApplication" value="StructuralMechanicsApplication"/>
                 </element_filters>
             </scheme>

--- a/kratos.gid/scripts/Writing.tcl
+++ b/kratos.gid/scripts/Writing.tcl
@@ -1368,7 +1368,9 @@ proc write::getPropertiesList {parts_un} {
             }
             set material_dict [dict create]
             set const_law_application [[Model::getConstitutiveLaw $constitutive_law] getAttribute "ImplementedInApplication"]
-            set const_law_fullname [join [list "KratosMultiphysics" $const_law_application $constitutive_law] "."]
+            # WV const_law_application
+            if {$const_law_application eq "KratosMultiphysics"} {set const_law_fullname [join [list "KratosMultiphysics" $constitutive_law] "."]} {set const_law_fullname [join [list "KratosMultiphysics" $const_law_application $constitutive_law] "."]}
+            
             dict set material_dict constitutive_law [dict create name $const_law_fullname]
             dict set material_dict Variables $variables_list
             dict set material_dict Tables dictnull


### PR DESCRIPTION
This PR adds the new truss and shell elements to the structural mechanics application interface. The old beam element has been commented (once the local axes issue is completely addressed we can uncomment it to include the new corotational beam).

Recall that the truss element issue regarding the CROSS_AREA variable, which is required to be written as KratosMultiphysics.StructuralMechanicsApplication.CROSS_AREA, is still pending... 