### PR TITLE
StructralMechanics Removed unnecessary Parameters

### DIFF
--- a/kratos.gid/apps/Structural/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/Structural/write/writeProjectParameters.tcl
@@ -96,19 +96,19 @@ proc Structural::write::getOldParametersDict { } {
     # GiD output configuration
     dict set projectParametersDict output_configuration [write::GetDefaultOutputDict]
 
-    # Restart options
-    set restartDict [dict create ]
-    dict set restartDict SaveRestart false
-    dict set restartDict RestartFrequency 0
-    dict set restartDict LoadRestart false
-    dict set restartDict Restart_Step 0
-    dict set projectParametersDict restart_options $restartDict
+    # # Restart options
+    # set restartDict [dict create ]
+    # dict set restartDict SaveRestart false
+    # dict set restartDict RestartFrequency 0
+    # dict set restartDict LoadRestart false
+    # dict set restartDict Restart_Step 0
+    # dict set projectParametersDict restart_options $restartDict
 
-    # Constraints data
-    set contraintsDict [dict create ]
-    dict set contraintsDict incremental_load false
-    dict set contraintsDict incremental_displacement false
-    dict set projectParametersDict constraints_data $contraintsDict
+    # # Constraints data
+    # set contraintsDict [dict create ]
+    # dict set contraintsDict incremental_load false
+    # dict set contraintsDict incremental_displacement false
+    # dict set projectParametersDict constraints_data $contraintsDict
 
     set check_list [list "UpdatedLagrangianElementUP2D" "UpdatedLagrangianElementUPAxisym"]
     foreach elem $check_list {


### PR DESCRIPTION
This PR removes the `restart_options` and the `constraints_data` from the Projectparameters

The restart options will be in the solver soon (I am working on this atm), the constraints data is not needed bcs this is done via processes

This is the first step of cleaning the Problemtype for release 5.3