### PR TITLE
Addition of Bbar element and J2 constitutive model to the interface

### DIFF
--- a/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
+++ b/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
@@ -53,10 +53,10 @@
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-            <parameter n="YIELD_STRESS" pn="Yield stress" unit_magnitude="P" units="Pa" v="278.0e9"/>
-            <parameter n="REFERENCE_HARDENING_MODULUS" pn="Kinematic hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
-            <parameter n="ISOTROPIC_HARDENING_MODULUS" pn="Isotropic hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
-            <parameter n="INFINITY_HARDENING_MODULUS" pn="Saturation hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
+            <parameter n="YIELD_STRESS" pn="Yield stress" unit_magnitude="P" units="Pa" v="5.5e6"/>
+            <parameter n="REFERENCE_HARDENING_MODULUS" pn="Kinematic hardening modulus" v="1.0"/>
+            <parameter n="ISOTROPIC_HARDENING_MODULUS" pn="Isotropic hardening modulus" v="0.12924"/>
+            <parameter n="INFINITY_HARDENING_MODULUS" pn="Saturation hardening modulus" v="0.0"/>
             <parameter n="HARDENING_EXPONENT" pn="Hardening exponent" v="1.0"/>
         </inputs>
         <outputs></outputs>
@@ -67,10 +67,10 @@
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
             <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
-            <parameter n="YIELD_STRESS" pn="Yield stress" unit_magnitude="P" units="Pa" v="278.0e9"/>
-            <parameter n="REFERENCE_HARDENING_MODULUS" pn="Kinematic hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
-            <parameter n="ISOTROPIC_HARDENING_MODULUS" pn="Isotropic hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
-            <parameter n="INFINITY_HARDENING_MODULUS" pn="Saturation hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
+            <parameter n="YIELD_STRESS" pn="Yield stress" unit_magnitude="P" units="Pa" v="5.5e6"/>
+            <parameter n="REFERENCE_HARDENING_MODULUS" pn="Kinematic hardening modulus" v="1.0"/>
+            <parameter n="ISOTROPIC_HARDENING_MODULUS" pn="Isotropic hardening modulus" v="0.12924"/>
+            <parameter n="INFINITY_HARDENING_MODULUS" pn="Saturation hardening modulus" v="0.0"/>
             <parameter n="HARDENING_EXPONENT" pn="Hardening exponent" v="1.0"/>
         </inputs>
         <outputs></outputs>

--- a/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
+++ b/kratos.gid/apps/Structural/xml/ConstitutiveLaws.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ConstitutiveLaws>
     <!--linear elastic laws-->
-    <CLaw n="LinearElastic3DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="3D" behaviour="Elastic" StrainSize="6"  ImplementedInApplication="StructuralMechanicsApplication"
+    <CLaw n="LinearElastic3DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="3D" Behaviour="Elastic" StrainSize="6"  ImplementedInApplication="StructuralMechanicsApplication"
 	  help="Linear elastic behaviour in 3D" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" AllowsAnisotropy="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
@@ -12,7 +12,7 @@
 
         </outputs>
     </CLaw>
-    <CLaw n="LinearElasticPlaneStrain2DLaw" pn="Linear Elastic Plane Strain" ProductionReady="ProductionReady" Type="PlaneStrain" behaviour="Elastic" StrainSize="3" ImplementedInApplication="StructuralMechanicsApplication"
+    <CLaw n="LinearElasticPlaneStrain2DLaw" pn="Linear Elastic Plane Strain" ProductionReady="ProductionReady" Type="PlaneStrain" Behaviour="Elastic" StrainSize="3" ImplementedInApplication="StructuralMechanicsApplication"
           help="Linear elastic behaviour in 2D plane strain" Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
@@ -23,7 +23,7 @@
 
         </outputs>
     </CLaw>
-    <CLaw n="LinearElasticPlaneStress2DLaw" pn="Linear Elastic Plane Stress" ProductionReady="ProductionReady" Type="PlaneStress" behaviour="Elastic" StrainSize="3" ImplementedInApplication="StructuralMechanicsApplication"
+    <CLaw n="LinearElasticPlaneStress2DLaw" pn="Linear Elastic Plane Stress" ProductionReady="ProductionReady" Type="PlaneStress" Behaviour="Elastic" StrainSize="3" ImplementedInApplication="StructuralMechanicsApplication"
           help="Linear elastic behaviour in 2D plane stress" Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
@@ -35,7 +35,7 @@
 
         </outputs>
     </CLaw>
-    <CLaw n="LinearElasticAxisym2DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="Axisymmetric" behaviour="Elastic" StrainSize="4" ImplementedInApplication="StructuralMechanicsApplication"
+    <CLaw n="LinearElasticAxisym2DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="Axisymmetric" Behaviour="Elastic" StrainSize="4" ImplementedInApplication="StructuralMechanicsApplication"
           help="Linear elastic behaviour in 2D axisymmetric" Dimension="2Da" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
@@ -47,8 +47,37 @@
         </outputs>
     </CLaw>
 
+    <!--plasticity constitutive laws-->
+    <CLaw n="LinearJ2PlasticityPlaneStrain2DLaw" pn="Linear J2 Plasticity" ProductionReady="ProductionReady" Type="PlaneStrain" Behaviour="Plasticity" StrainSize="4" ImplementedInApplication="StructuralMechanicsApplication" help="Simo J2 plasticity constitutive law in 2D (Plane Strain)" Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False">
+        <inputs>
+            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
+            <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
+            <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
+            <parameter n="YIELD_STRESS" pn="Yield stress" unit_magnitude="P" units="Pa" v="278.0e9"/>
+            <parameter n="REFERENCE_HARDENING_MODULUS" pn="Kinematic hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
+            <parameter n="ISOTROPIC_HARDENING_MODULUS" pn="Isotropic hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
+            <parameter n="INFINITY_HARDENING_MODULUS" pn="Saturation hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
+            <parameter n="HARDENING_EXPONENT" pn="Hardening exponent" v="1.0"/>
+        </inputs>
+        <outputs></outputs>
+    </CLaw>
+
+    <CLaw n="LinearJ2Plasticity3DLaw" pn="Linear J2 Plasticity" ProductionReady="ProductionReady" Type="3D" Behaviour="Plasticity" StrainSize="6" ImplementedInApplication="StructuralMechanicsApplication" help="Simo J2 plasticity constitutive law in 3D" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False">
+        <inputs>
+            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
+            <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
+            <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29"/>
+            <parameter n="YIELD_STRESS" pn="Yield stress" unit_magnitude="P" units="Pa" v="278.0e9"/>
+            <parameter n="REFERENCE_HARDENING_MODULUS" pn="Kinematic hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
+            <parameter n="ISOTROPIC_HARDENING_MODULUS" pn="Isotropic hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
+            <parameter n="INFINITY_HARDENING_MODULUS" pn="Saturation hardening modulus" unit_magnitude="P" units="Pa" v="1.0"/>
+            <parameter n="HARDENING_EXPONENT" pn="Hardening exponent" v="1.0"/>
+        </inputs>
+        <outputs></outputs>
+    </CLaw>
+
     <!--constitutive laws for shells and membranes-->
-    <CLaw n="LinearElasticPlaneStress_Hybrid_3D" KratosName="LinearElasticPlaneStress2DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="PlaneStress" behaviour="Elastic" StrainSize="6"  ImplementedInApplication="StructuralMechanicsApplication"
+    <CLaw n="LinearElasticPlaneStress_Hybrid_3D" KratosName="LinearElasticPlaneStress2DLaw" pn="Linear Elastic" ProductionReady="ProductionReady" Type="PlaneStress" Behaviour="Elastic" StrainSize="6"  ImplementedInApplication="StructuralMechanicsApplication"
 	  help="Linear elastic behaviour in 3D for shells" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="D-R" AllowsAnisotropy="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density"/>
@@ -60,7 +89,7 @@
 
         </outputs>
     </CLaw>
-    <CLaw n="LinearElasticPlaneStress_3D" KratosName="LinearElasticPlaneStress2DLaw" pn="Linear Elastic Plane Stress" ProductionReady="ProductionReady" Type="PlaneStress" behaviour="Elastic" StrainSize="3" ImplementedInApplication="StructuralMechanicsApplication"
+    <CLaw n="LinearElasticPlaneStress_3D" KratosName="LinearElasticPlaneStress2DLaw" pn="Linear Elastic Plane Stress" ProductionReady="ProductionReady" Type="PlaneStress" Behaviour="Elastic" StrainSize="3" ImplementedInApplication="StructuralMechanicsApplication"
           help="Linear elastic behaviour in 2D plane stress" Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False" >
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
@@ -74,7 +103,7 @@
     </CLaw>
 
     <!--constitutive laws for trusses-->
-    <CLaw n="TrussConstitutiveLaw" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" behaviour="Elastic" StrainSize="1" ImplementedInApplication="StructuralMechanicsApplication" help="Linear elastic behaviour for trusses" Dimension="2D,3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False">
+    <CLaw n="TrussConstitutiveLaw" pn="Linear elastic truss" ProductionReady="ProductionReady" Type="Truss" Behaviour="Elastic" StrainSize="1" ImplementedInApplication="StructuralMechanicsApplication" help="Linear elastic behaviour for trusses" Dimension="2D,3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False">
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="7850"/>
             <parameter n="YOUNG_MODULUS" pn="Young Modulus" unit_magnitude="P" units="Pa" v="206.9e9" />
@@ -85,7 +114,7 @@
     </CLaw>
 
     <!--constitutive laws for beams-->
-    <CLaw n="BeamConstitutiveLaw2D" KratosName="BeamConstitutiveLaw" pn="Linear elastic beam" ProductionReady="ProductionReady" Type="Beam2D" behaviour="Elastic"
+    <CLaw n="BeamConstitutiveLaw2D" KratosName="BeamConstitutiveLaw" pn="Linear elastic beam" ProductionReady="ProductionReady" Type="Beam2D" Behaviour="Elastic"
           StrainSize="1" ImplementedInApplication="StructuralMechanicsApplication" help="Linear elastic behaviour for beams"
           Dimension="2D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False">
         <inputs>
@@ -98,7 +127,7 @@
         <outputs></outputs>
     </CLaw>
 
-    <CLaw n="BeamConstitutiveLaw3D" KratosName="BeamConstitutiveLaw" pn="Linear elastic beam" ProductionReady="ProductionReady" Type="Beam3D" behaviour="Elastic"
+    <CLaw n="BeamConstitutiveLaw3D" KratosName="BeamConstitutiveLaw" pn="Linear elastic beam" ProductionReady="ProductionReady" Type="Beam3D" Behaviour="Elastic"
           StrainSize="1" ImplementedInApplication="StructuralMechanicsApplication" help="Linear elastic behaviour for beams"
           Dimension="3D" LargeDeformation="False" RequiresLocalAxes="False" HybridType="False">
         <inputs>

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -113,6 +113,73 @@
     </outputs>
   </ElementItem>
 
+  <!--Bbar elements-->
+  <ElementItem n="SmallDisplacementBbarElement2D" pn="Solid small displacements Bbar" ImplementedInFile="small_displacement_bbar.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid"
+               help="This element it implements a small displacement Bbar solid element"  AnalysisType="linear,non_linear">
+    <!--here we could add a list of all of the possible geometries-->
+    <TopologyFeatures>
+      <item GeometryType="Quadrilateral" nodes="4" KratosName="SmallDisplacementBbarElement2D4N"/>
+    </TopologyFeatures>
+    <!-- here we add the block of features which we require from the constitutive law-->
+    <ConstitutiveLaw_FilterFeatures>
+      <filter field="Type" value="PlaneStrain"/>
+      <filter field="Dimension" value="2D"/>
+      <filter field="Behaviour" value="Plasticity"/>
+      <filter field="StrainSize" value="4"/>
+      <filter field="HybridType" value="False"/>
+      <filter field="LargeDeformation" value="False"/>
+    </ConstitutiveLaw_FilterFeatures>
+    <!--define list of NodalConditions-->
+    <NodalConditions>
+      <NodalCondition n="DISPLACEMENT"/>
+      <NodalCondition n="VELOCITY"/>
+      <NodalCondition n="ACCELERATION"/>
+      <NodalCondition n="CONTACT"/>
+    </NodalConditions>
+    <inputs></inputs>
+    <outputs>
+      <parameter n="GREEN_LAGRANGE_STRAIN_TENSOR" pn="Green-Lagrange strain tensor" v="true" />
+      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" v="true" />
+      <parameter n="VON_MISES_STRESS" pn="Von Mises stress value" v="true" />
+      <parameter n="ALMANSI_STRAIN_TENSOR" pn="Almansi Strain Tensor" v="false" state="hidden" />
+      <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
+    </outputs>
+  </ElementItem>
+
+  <ElementItem n="SmallDisplacementBbarElement3D" pn="Solid small displacements Bbar" ImplementedInFile="small_displacement_bbar.cpp" ImplementedInApplication="StructuralMechanicsApplication"
+               MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid"
+               help="This element it implements a small displacement Bbar solid element"  AnalysisType="linear,non_linear">
+    <!--here we could add a list of all of the possible geometries-->
+    <TopologyFeatures>
+      <item GeometryType="Hexahedra" nodes="8" KratosName="SmallDisplacementBbarElement3D8N"/>
+    </TopologyFeatures>
+    <!-- here we add the block of features which we require from the constitutive law-->
+    <ConstitutiveLaw_FilterFeatures>
+      <filter field="Type" value="3D"/>
+      <filter field="Dimension" value="3D"/>
+      <filter field="Behaviour" value="Plasticity"/>
+      <filter field="StrainSize" value="6"/>
+      <filter field="HybridType" value="False"/>
+      <filter field="LargeDeformation" value="False"/>
+    </ConstitutiveLaw_FilterFeatures>
+    <!--define list of NodalConditions-->
+    <NodalConditions>
+      <NodalCondition n="DISPLACEMENT"/>
+      <NodalCondition n="VELOCITY"/>
+      <NodalCondition n="ACCELERATION"/>
+      <NodalCondition n="CONTACT"/>
+    </NodalConditions>
+    <inputs></inputs>
+    <outputs>
+      <parameter n="GREEN_LAGRANGE_STRAIN_TENSOR" pn="Green-Lagrange strain tensor" v="true" />
+      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" v="true" />
+      <parameter n="VON_MISES_STRESS" pn="Von Mises stress value" v="true" />
+      <parameter n="ALMANSI_STRAIN_TENSOR" pn="Almansi Strain Tensor" v="false" state="hidden" />
+      <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
+    </outputs>
+  </ElementItem>
+
   <!--large displacements-->
   <!--total lagrangian-->
   <ElementItem n="TotalLagrangianElement2D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication"

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -158,7 +158,6 @@
     <ConstitutiveLaw_FilterFeatures>
       <filter field="Type" value="3D"/>
       <filter field="Dimension" value="3D"/>
-      <filter field="Behaviour" value="Plasticity"/>
       <filter field="StrainSize" value="6"/>
       <filter field="HybridType" value="False"/>
       <filter field="LargeDeformation" value="False"/>

--- a/kratos.gid/apps/Structural/xml/Materials.xml
+++ b/kratos.gid/apps/Structural/xml/Materials.xml
@@ -5,6 +5,11 @@
         <parameter n="DENSITY" pn="Density" v="7850" help="Density of the material" unit_magnitude="M/L^3" units="kg/m^3"/>
         <parameter n="YOUNG_MODULUS" pn="Young Modulus" v="206.9e9" help="Elastic modulus of the material" unit_magnitude="F/L^2" units="N/m^2"/>
         <parameter n="POISSON_RATIO" pn="Poisson Ratio" v="0.29" help="Poisson coefficient of the material"/>
+        <parameter n="YIELD_STRESS" pn="Yield stress" unit_magnitude="P" units="Pa" v="5.5e6"/>
+        <parameter n="REFERENCE_HARDENING_MODULUS" pn="Kinematic hardening modulus" v="1.0"/>
+        <parameter n="ISOTROPIC_HARDENING_MODULUS" pn="Isotropic hardening modulus" v="0.12924"/>
+        <parameter n="INFINITY_HARDENING_MODULUS" pn="Saturation hardening modulus" v="0.0"/>
+        <parameter n="HARDENING_EXPONENT" pn="Hardening exponent" v="1.0"/>
     </inputs>
   </Material>
   <Material n="Aluminium" MaterialType="Structural" help="This element implements a Fractional Step Element">


### PR DESCRIPTION
@KratosMultiphysics/structural-mechanics team, I've added the Bbar element together with the J2 constitutive model. However, I still have some doubts so I'm opening the PR to start the discussion.

- the Bbar elements can only work with the J2 cons. law or can we use other cons. laws?
- default values for the REFERENCE_HARDENING_MODULUS, REFERENCE_HARDENING_MODULUS, INFINITY_HARDENING_MODULUS and HARDENING_EXPONENT. Recall that in the interface we have as default materials steel and aluminium, so it would be nice if you can provide these magnitudes for these materials.
- are you interesting in any output variable different to the common ones?