### PR TITLE
Mdpa import mesh

### DIFF
--- a/kratos.gid/kratos.tcl
+++ b/kratos.gid/kratos.tcl
@@ -152,7 +152,7 @@ proc Kratos::InitGIDProject { dir } {
         uplevel 1 [list source [file join $dir scripts $filename]]
     }
     # JG Sources will be in a different proc
-    foreach filename {ApplicationMarketWindow.tcl CommonProcs.tcl TreeInjections.tcl} {
+    foreach filename {ApplicationMarketWindow.tcl CommonProcs.tcl TreeInjections.tcl MdpaImportMesh.tcl} {
         uplevel 1 [list source [file join $dir scripts Controllers $filename]]
     }
     

--- a/kratos.gid/scripts/Controllers/MdpaImportMesh.tcl
+++ b/kratos.gid/scripts/Controllers/MdpaImportMesh.tcl
@@ -1,0 +1,214 @@
+proc Kratos::ReadPreW { } {
+    set filename [Browser-ramR file read .gid [_ "Read UNV file"] {} {{{Model part} {.mdpa }}} ]
+    if {$filename == ""} {
+        return
+    }
+    GidUtils::EvalAndEnterInBatch Kratos::ReadPre $filename
+}
+
+
+#to drag and drop a file
+proc Kratos::ReadPreSingleFile { filename } {
+    GidUtils::EvalAndEnterInBatch Kratos::ReadPre $filename
+}
+
+#create could be GEOMETRY or MESH
+proc Kratos::ReadPre { filename } {
+    if { ![file exists $filename] } { 
+        WarnWin [_ "file '%s' not exists" $filename]
+        return 1
+    }   
+    set fp [open $filename r]
+    if { $fp == "" } {
+        WarnWin [_ "Cannot open file '%s'" $filename]
+        return 1
+    }
+    #offset_nodes to be added to the number if a previous model exists
+    set offset_nodes [GiD_Info Mesh MaxNumNodes]
+    set offset_elements [GiD_Info Mesh MaxNumElements]
+    set conditions_dict [dict create]
+    set layer Layer0
+    set fail 0
+    set state 0
+    ::GidUtils::WaitState
+    while { ![eof $fp] } {
+        # take next line
+        gets $fp line
+
+        if {$line eq "Begin Nodes"} {
+            while { ![eof $fp] } {
+                gets $fp line
+                if {$line ne "End Nodes"} {
+                    lassign [regsub -all {\s+}  $line " "] id x y z
+                    GiD_Mesh create node [expr $offset_nodes + $id] [list $x $y $z]
+                } else {
+                    break
+                }
+            }
+        }
+        if {[string match "Begin Elements*" $line]} {
+            set element_type [Kratos::GuessElementTypeFromMDPA $line]
+            while { ![eof $fp] } {
+                gets $fp line
+                if {$line ne "End Elements"} {
+                    # lo del elemento
+                    set raw [regsub -all {\s+}  $line " "]
+                    set id [lindex $raw 0]
+                    set nodes [lrange $raw 2 end]
+                    set nodes_new [list ]
+                    foreach node $nodes {lappend nodes_new [expr $node + $offset_nodes]}
+                    GiD_Mesh create element [expr $offset_elements + $id] $element_type [llength $nodes_new] $nodes_new
+                } else {
+                    break
+                }
+            }
+        }
+        if {[string match "Begin Conditions*" $line]} {
+            set element_type [Kratos::GuessElementTypeFromMDPA $line]
+            while { ![eof $fp] } {
+                gets $fp line
+                if {$line ne "End Conditions"} {
+                    # lo del elemento
+                    set raw [regsub -all {\s+}  $line " "]
+                    set id [lindex $raw 0]
+                    if {$id in [dict exists $conditions_dict $id]} {next}
+                    set nodes [lrange $raw 2 end]
+                    set nodes_new [list ]
+                    foreach node $nodes {lappend nodes_new [expr $node + $offset_nodes]}
+                    set new_id [GiD_Mesh create element append $element_type [llength $nodes_new] $nodes_new]
+                    dict set conditions_dict $id $new_id
+                } else {
+                    break
+                }
+            }
+        }
+        if {[string match "Begin SubModelPart*" $line]} {
+            set group_name [lindex [split [lindex $line 2] "//"] 0]
+            set group_name_orig $group_name
+            set i 0
+            while {[GiD_Groups exists $group_name]} {set group_name [string cat "Imported_" $group_name_orig "_" [incr i]]}
+            GiD_Groups create $group_name
+            while { ![eof $fp] } {
+                gets $fp line
+                if {[string trim $line] ne "End SubModelPart"} {
+                    if {[string trim $line] eq "Begin SubModelPartNodes"} {
+                        while { ![eof $fp] } {
+                            gets $fp line
+                            if {[string trim $line] ne "End SubModelPartNodes"} {
+                                GiD_EntitiesGroups assign $group_name nodes [expr $offset_nodes + [string trim $line]]
+                            } else {
+                                break
+                            }
+                        }
+                    }
+                    if {[string trim $line] eq "Begin SubModelPartElements"} {
+                        while { ![eof $fp] } {
+                            gets $fp line
+                            if {[string trim $line] ne "End SubModelPartElements"} {
+                                GiD_EntitiesGroups assign $group_name elements [expr $offset_elements + [string trim $line]]
+                            } else {
+                                break
+                            }
+                        }
+                    }
+                    if {[string trim $line] eq "Begin SubModelPartConditions"} {
+                        while { ![eof $fp] } {
+                            gets $fp line
+                            if {[string trim $line] ne "End SubModelPartConditions"} {
+                                GiD_EntitiesGroups assign $group_name elements [dict get $conditions_dict [string trim $line]]
+                            } else {
+                                break
+                            }
+                        }
+                    }
+                } else {
+                    break
+                }
+            }
+        }
+    }
+    close $fp
+
+    ::GidUtils::EndWaitState
+    ::GidUtils::SetWarnLine [_ "File read"]
+
+    if { [GiD_Info project ViewMode] != "MESHUSE" } {
+        GiD_Process MEscape Meshing MeshView
+    }
+
+    #GiD_Redraw
+    GiD_Process Mescape View Zoom Frame escape
+    if { [info commands GiD_Groups] != "" } {
+        Groups::FillInfo
+    }
+    
+    #RaiseEvent_GenericProc ::AfterOpenFile $filename UNV_FORMAT 0
+    return 0
+}
+
+proc Kratos::GuessElementTypeFromMDPA {line} {
+    set element_type "unknown"
+    set element_name [lindex $line 2]
+    set element_name [lindex [split $element_name "//"] 0]
+    
+    if {$element_name eq "Sphere3D"} {
+        set element_type "Sphere"
+    } else {
+        set dim [string index $element_name end-3]
+        set nnodes [string index $element_name end-1]
+        switch $nnodes {
+            2 {
+                set element_type "Line"
+            }
+            3 {
+                set element_type "Triangle"
+            }
+            4 {
+                if {$dim eq 2} {
+                    set element_type "Quadrilateral"
+                } else {
+                    set element_type "Tetraedra"
+                }
+            }
+            5 {
+                set element_type "Pyramid"
+            }
+            6 { 
+                if {$dim eq 2} {
+                    set element_type "Triangle"
+                } else {
+                    set element_type "Prism"
+                }
+            }
+            8 { 
+                if {$dim eq 2} {
+                    set element_type "Quadrilateral"
+                } else {
+                    set element_type "Hexaedra"
+                }
+            }
+            9 {
+                set element_type "Quadrilateral"
+            }
+            10 {
+                set element_type "Tetraedra"
+            }
+            13 {
+                set element_type "Pyramid"
+            }
+            15 {
+                set element_type "Prism"
+            }
+            18 {
+                set element_type "Prism"
+            }
+            20 {
+                set element_type "Hexaedra"
+            }
+            27 {
+                set element_type "Hexaedra"
+            }
+        }
+    }
+    return $element_type
+}

--- a/kratos.gid/scripts/Controllers/MdpaImportMesh.tcl
+++ b/kratos.gid/scripts/Controllers/MdpaImportMesh.tcl
@@ -1,5 +1,5 @@
 proc Kratos::ReadPreW { } {
-    set filename [Browser-ramR file read .gid [_ "Read UNV file"] {} {{{Model part} {.mdpa }}} ]
+    set filename [Browser-ramR file read .gid [_ "Kratos - Read Mdpa file"] {} {{{Model part} {.mdpa }}} ]
     if {$filename == ""} {
         return
     }
@@ -212,3 +212,6 @@ proc Kratos::GuessElementTypeFromMDPA {line} {
     }
     return $element_type
 }
+
+#register the proc to be automatically called when dropping a file
+GiD_RegisterExtensionProc ".mdpa" PRE Kratos::ReadPreSingleFile

--- a/kratos.gid/scripts/Menus.tcl
+++ b/kratos.gid/scripts/Menus.tcl
@@ -122,6 +122,8 @@ proc Kratos::ChangeMenus { } {
         GiDMenu::InsertOption "Kratos" [list "Wizard window" ] [incr pos] PRE [list Wizard::CreateWindow] "" "" replace =
     }
     GiDMenu::InsertOption "Kratos" [list "---"] [incr pos] PRE "" "" "" replace =
+    GiDMenu::InsertOption "Kratos" [list "Import MDPA"] [incr pos] PRE [list Kratos::ReadPreW] "" "" replace =
+    GiDMenu::InsertOption "Kratos" [list "---"] [incr pos] PRE "" "" "" replace =
     GiDMenu::InsertOption "Kratos" [list "About Kratos" ] [incr pos] PREPOST [list Kratos::About] "" "" replace =
     GidChangeDataLabel "Data units" ""
     GidChangeDataLabel "Interval" ""


### PR DESCRIPTION
Utility to import an mdpa into the model.

Imports the nodes and the elements, according to Elements and Conditions, and generates groups according to SubModelParts

- It **does not interact with the Kratos tree** 
- It may **not keep the nodes and element id**, (if previous mesh existing in the model)

It can be found in the Kratos menu tab

![image](https://user-images.githubusercontent.com/5918085/43833114-ffb121da-9b09-11e8-86ee-59912e5fa80a.png)


Just mention @KratosMultiphysics/technical-committee so they can be informed of this new feature