### PR TITLE
removing "KratosMultiphysisc.AppName" from ConstLaw-Name

### DIFF
--- a/kratos.gid/scripts/Writing.tcl
+++ b/kratos.gid/scripts/Writing.tcl
@@ -1586,14 +1586,8 @@ proc write::getPropertiesList {parts_un {write_claw_name "True"}} {
                 set material_dict [dict create]
 
                 if {$write_claw_name eq "True"} {
-                    set const_law_application [$constitutive_law getAttribute "ImplementedInApplication"]
                     set constitutive_law_name [$constitutive_law getKratosName]
-                    if {$const_law_application eq "KratosMultiphysics"} {
-                        set const_law_fullname [join [list "KratosMultiphysics" $constitutive_law_name] "."]
-                    } {
-                        set const_law_fullname [join [list "KratosMultiphysics" $const_law_application $constitutive_law_name] "."]
-                    }
-                    dict set material_dict constitutive_law [dict create name $const_law_fullname]
+                    dict set material_dict constitutive_law [dict create name $constitutive_law_name]
                 }
                 dict set material_dict Variables $variables_list
                 dict set material_dict Tables dictnull


### PR DESCRIPTION
turns 
~~~
{
    "properties" : [{
        "model_part_name" : "Parts_Parts_Auto1",
        "properties_id"   : 1,
        "Material"        : {
            "constitutive_law" : {
                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
            },
            "Variables"        : {
                "THICKNESS"     : 1.0,
                "DENSITY"       : 7850.0,
                "YOUNG_MODULUS" : 206900000000.0,
                "POISSON_RATIO" : 0.29
            },
            "Tables"           : {}
        }
    }]
}
~~~

into

~~~
{
    "properties" : [{
        "model_part_name" : "Parts_Parts_Auto1",
        "properties_id"   : 1,
        "Material"        : {
            "constitutive_law" : {
                "name" : "LinearElasticPlaneStress2DLaw"
            },
            "Variables"        : {
                "THICKNESS"     : 1.0,
                "DENSITY"       : 7850.0,
                "YOUNG_MODULUS" : 206900000000.0,
                "POISSON_RATIO" : 0.29
            },
            "Tables"           : {}
        }
    }]
}
~~~

@jginternational the `KratosMultiphysics.StructuralMechanicsApplication.` in front of the Claw-Name is ignored in Kratos for a while already

closes #418 