### PR TITLE
Fix write conditions for embedded

### DIFF
--- a/kratos.gid/apps/EmbeddedFluid/write/write.tcl
+++ b/kratos.gid/apps/EmbeddedFluid/write/write.tcl
@@ -19,6 +19,7 @@ proc EmbeddedFluid::write::writeModelPartEvent { } {
     # Fluid::write::AddValidApps "EmbeddedFluid"
     set err [Fluid::write::Validate]
     if {$err ne ""} {error $err}
+    set Fluid::write::FluidConditionMap [objarray new intarray [expr [GiD_Info Mesh MaxNumElements] +1] 0]
     write::initWriteConfiguration [GetAttributes]
     write::writeModelPartData
     Fluid::write::writeProperties
@@ -28,6 +29,7 @@ proc EmbeddedFluid::write::writeModelPartEvent { } {
     Fluid::write::writeConditions
     Fluid::write::writeMeshes
     writeDistances
+    unset Fluid::write::FluidConditionMap
 }
 proc EmbeddedFluid::write::writeCustomFilesEvent { } {
     write::CopyFileIntoModel "python/KratosFluid.py"

--- a/kratos.gid/apps/Fluid/write/write.tcl
+++ b/kratos.gid/apps/Fluid/write/write.tcl
@@ -56,6 +56,7 @@ proc Fluid::write::writeModelPartEvent { } {
     
     # Custom SubmodelParts
     #write::writeBasicSubmodelParts
+    unset Fluid::write::FluidConditionMap
 }
 proc Fluid::write::writeCustomFilesEvent { } {
     # Materials file TODO -> Python script must read from here


### PR DESCRIPTION
@merceln @rubenzorrilla 
This fixes the write process
But it still not working

```
  File "E:\PROYECTOS\KratosGiD\kratos.gid\exec\kratos\kratos\python_scripts\python_solver.py", line 150, in _ImportModelPart
    KratosMultiphysics.ModelPartIO(input_filename, import_flags).ReadModelPart(model_part)
RuntimeError: Error: Condition WallCondition2D3N is not registered in Kratos. Please check the spelling of the condition name and see if the application containing it is registered corectly. [Line 5173713 ]
```