### PR TITLE
Removing inlet and wake direction (they are internally defined in Kratos)

### DIFF
--- a/kratos.gid/apps/PotentialFluid/examples/NACA0012.tcl
+++ b/kratos.gid/apps/PotentialFluid/examples/NACA0012.tcl
@@ -134,7 +134,7 @@ proc PotentialFluid::examples::TreeAssignationNACA00122D {args} {
     set fluidFarField "$fluidConditions/condition\[@n='PotentialWallCondition$nd'\]"
     set farFieldNode [customlib::AddConditionGroupOnXPath $fluidFarField FarField]
     $farFieldNode setAttribute ov $condtype
-    set props [list inlet_phi 1.0 velocity_infinityX 10.0 velocity_infinityY 0.0 velocity_infinityZ 0.0]
+    set props [list velocity_infinityX 10.0 velocity_infinityY 0.0 velocity_infinityZ 0.0]
     foreach {prop val} $props {
          set propnode [$farFieldNode selectNodes "./value\[@n = '$prop'\]"]
          if {$propnode ne "" } {

--- a/kratos.gid/apps/PotentialFluid/python/KratosPotentialFluid.py
+++ b/kratos.gid/apps/PotentialFluid/python/KratosPotentialFluid.py
@@ -1,4 +1,5 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
+#makes KratosMultiphysics backward compatible with python 2.6 and 2.7
+from __future__ import print_function, absolute_import, division 
 
 import KratosMultiphysics
 

--- a/kratos.gid/apps/PotentialFluid/python/KratosPotentialFluid.py
+++ b/kratos.gid/apps/PotentialFluid/python/KratosPotentialFluid.py
@@ -1,5 +1,5 @@
 #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-from __future__ import print_function, absolute_import, division 
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 

--- a/kratos.gid/apps/PotentialFluid/xml/Processes.xml
+++ b/kratos.gid/apps/PotentialFluid/xml/Processes.xml
@@ -3,8 +3,6 @@
 <ProcessList>
 	<Process n="DefineWakeProcess2D" pn="Scalar value" python_module="define_wake_process_2d" kratos_module="KratosMultiphysics.CompressiblePotentialFlowApplication">
 		<inputs>
-			<parameter n="wake_direction" pn="Wake direction" type="vector" v="1.0,0.0,0.0" vectorType="double" help=""/>
-			<parameter n="epsilon" pn="Epsilon" type="double" v="1e-6" help=""/>
 		</inputs>
 	</Process>
 
@@ -17,7 +15,6 @@
 
 	<Process n="FarFieldProcess" pn="Far Field Process" python_module="apply_far_field_process" kratos_module="KratosMultiphysics.CompressiblePotentialFlowApplication">
 		<inputs>
-			<parameter n="inlet_phi" pn="Inlet phi" type="double" v="1.0" help=""/>
 			<parameter n="velocity_infinity" pn="Velocity infinity" type="vector" v="1.0,0.0,0.0" vectorType="double" help=""/>
 		</inputs>
 	</Process>


### PR DESCRIPTION
This is a small pull request to remove the setting of the potential in the inlet and the wake direction.

The potential at the inlet does not affect the results so it will be automatically set inside Kratos and the wake direction is always the free stream direction.

I updated the example as @rubenzorrilla showed me.