### PR TITLE
[Structural] Shell force, moment and stresses output

### DIFF
--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -339,7 +339,14 @@
       <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m" />
     </inputs>
     <outputs>
-      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
+      <parameter n="SHELL_FORCE_GLOBAL" pn="Shell forces" v="false" />
+      <parameter n="SHELL_MOMENT_GLOBAL" pn="Shell moments" v="false" />
+      <parameter n="SHELL_STRESS_TOP_SURFACE_GLOBAL" pn="Stress - top surface" v="false" />
+      <parameter n="SHELL_STRESS_MIDDLE_SURFACE_GLOBAL" pn="Stress - mid surface" v="false" />
+      <parameter n="SHELL_STRESS_BOTTOM_SURFACE_GLOBAL" pn="Stress - bottom surface" v="false" />
+      <parameter n="VON_MISES_STRESS_TOP_SURFACE" pn="Von Mises stress - top surface" v="true" />
+      <parameter n="VON_MISES_STRESS_MIDDLE_SURFACE" pn="Von Mises stress - mid surface" v="true" />
+      <parameter n="VON_MISES_STRESS_BOTTOM_SURFACE" pn="Von Mises stress - bottom surface" v="true" />
     </outputs>
   </ElementItem>
   <ElementItem n="ShellThickCorotationalElement" pn="Shell thick corotational" ImplementedInFile="shell_thick_element_3DxN.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" help="This element implements a corotational element for thick shells in a large displacements approach" ElementType="Shell" RotationDofs="True" AnalysisType="linear,non_linear">
@@ -370,7 +377,14 @@
       <parameter n="THICKNESS" pn="Thickness" v="1.0" unit_magnitude="L" units="m" />
     </inputs>
     <outputs>
-      <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
+      <parameter n="SHELL_FORCE_GLOBAL" pn="Shell forces" v="false" />
+      <parameter n="SHELL_MOMENT_GLOBAL" pn="Shell moments" v="false" />
+      <parameter n="SHELL_STRESS_TOP_SURFACE_GLOBAL" pn="Stress - top surface" v="false" />
+      <parameter n="SHELL_STRESS_MIDDLE_SURFACE_GLOBAL" pn="Stress - mid surface" v="false" />
+      <parameter n="SHELL_STRESS_BOTTOM_SURFACE_GLOBAL" pn="Stress - bottom surface" v="false" />
+      <parameter n="VON_MISES_STRESS_TOP_SURFACE" pn="Von Mises stress - top surface" v="true" />
+      <parameter n="VON_MISES_STRESS_MIDDLE_SURFACE" pn="Von Mises stress - mid surface" v="true" />
+      <parameter n="VON_MISES_STRESS_BOTTOM_SURFACE" pn="Von Mises stress - bottom surface" v="true" />
     </outputs>
   </ElementItem>
   <!--membrane elements-->


### PR DESCRIPTION
@adityaghantasala this adds the Von Mises stresses as well as what @clazaro suggested in #566. I tried it and works for both the thin and thick shell.
By default, it only prints the Von Mises stress in the top, mid and bottom layers of the shells. To me it seems a bit verbose to print everything by default.

By the way, do you know any well-known shell benchmark case? It would be nice to implement it as a predefined example.

closes #566 