### PR TITLE
change ov in groups that did not use the GiD mesher

### DIFF
--- a/kratos.gid/apps/DEM/write/write.tcl
+++ b/kratos.gid/apps/DEM/write/write.tcl
@@ -3,6 +3,7 @@ namespace eval DEM::write {
     variable inletProperties
     variable last_property_id
     variable delete_previous_mdpa
+    variable restore_ov
 }
 
 proc DEM::write::Init { } {
@@ -27,6 +28,9 @@ proc DEM::write::Init { } {
 
     variable delete_previous_mdpa
     set delete_previous_mdpa 1
+    
+    variable restore_ov
+    set restore_ov [dict create]
 }
 
 # MDPA Blocks

--- a/kratos.gid/apps/DEM/write/writeMDPA_Parts.tcl
+++ b/kratos.gid/apps/DEM/write/writeMDPA_Parts.tcl
@@ -17,7 +17,9 @@ proc DEM::write::WriteMDPAParts { } {
     write::writeNodalCoordinatesOnGroups [GetDEMGroupsBoundayC]
 
     # Element connectivities (Groups on STParts)
+    PrepareCustomMeshedParts
     write::writeElementConnectivities; # Begin elements SphericContinuumParticle3D
+    RestoreCustomMeshedParts
 
     # Element radius
     writeSphereRadius; # Begin NodalData RADIUS
@@ -371,4 +373,30 @@ proc DEM::write::writeMaterialsParts { } {
             write::WriteString "End Properties\n"
         }
     }
+}
+
+proc DEM::write::PrepareCustomMeshedParts { } {
+    variable restore_ov
+    set root [customlib::GetBaseRoot]
+    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/group"
+    foreach group [$root selectNodes $xp1] {
+        set groupid [$group @n]
+        set prev_ov [$group @ov]
+        dict set restore_ov $groupid $prev_ov
+        $group setAttribute ov volume
+    }
+}
+
+proc DEM::write::RestoreCustomMeshedParts { } {
+    variable restore_ov
+    set root [customlib::GetBaseRoot]
+    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/group"
+    foreach group [$root selectNodes $xp1] {
+        set groupid [$group @n]
+        if {$groupid in [dict keys $restore_ov]} {
+            set prev_ov [dict get $restore_ov $groupid]
+            $group setAttribute ov $prev_ov
+        }
+    }
+    set restore_ov [dict create]
 }


### PR DESCRIPTION
In DEM Parts created over points, lines or surfaces, using the custom mesher, we must tell the writing procedures that the elements will be volumes (spheres) instead of points, lines...

In addition, I've fixed the mesher algorithm that tried to delete elements by element type even if the group didn't contain that element type.

@KratosMultiphysics/dem 