### PR TITLE
Parts by 'element family'

### DIFF
--- a/kratos.gid/apps/FSI/examples/HighRiseBuilding.tcl
+++ b/kratos.gid/apps/FSI/examples/HighRiseBuilding.tcl
@@ -164,7 +164,7 @@ proc FSI::examples::TreeAssignationHighRiseBuilding {args} {
     gid_groups_conds::setAttributesF {container[@n='FSI']/container[@n='Structural']/container[@n='StageInfo']/value[@n='SolutionType']} {v Dynamic}
 
     # Structural Parts
-    set structParts {container[@n='FSI']/container[@n='Structural']/condition[@n='Parts']}
+    set structParts {container[@n='FSI']/container[@n='Structural']/container[@n='Parts']/condition[@n='Parts_Solid']}
     set structPartsNode [customlib::AddConditionGroupOnXPath $structParts Structure]
     $structPartsNode setAttribute ov surface
     set constLawNameStruc "LinearElasticPlaneStress2DLaw"

--- a/kratos.gid/apps/FSI/examples/MokChannelWithFlexibleWall.tcl
+++ b/kratos.gid/apps/FSI/examples/MokChannelWithFlexibleWall.tcl
@@ -307,7 +307,7 @@ proc FSI::examples::TreeAssignationMokChannelFlexibleWall {args} {
     gid_groups_conds::setAttributesF {container[@n='FSI']/container[@n='Structural']/container[@n='StageInfo']/value[@n='SolutionType']} {v Dynamic}
 
     # Structural Parts
-    set structParts {container[@n='FSI']/container[@n='Structural']/condition[@n='Parts']}
+    set structParts {container[@n='FSI']/container[@n='Structural']/container[@n='Parts']/condition[@n='Parts_Solid']}
     set structPartsNode [customlib::AddConditionGroupOnXPath $structParts Structure]
     $structPartsNode setAttribute ov [expr {$nd == "3D" ? "volume" : "surface"}]
     set constLawNameStruc [expr {$nd == "3D" ? "LinearElastic3DLaw" : "LinearElasticPlaneStress2DLaw"}]

--- a/kratos.gid/apps/FSI/examples/TurekBenchmark.tcl
+++ b/kratos.gid/apps/FSI/examples/TurekBenchmark.tcl
@@ -27,16 +27,16 @@ proc FSI::examples::DrawTurekBenchmarkFluidGeometry {args} {
 
     # Set fluid domain geometry
     if {$::Model::SpatialDimension eq "2D"} {
-        GiD_Process 'Layers ChangeName Layer0 Fluid escape Mescape \
-        Geometry Create Object Rectangle 0,0 2.5,0.41 Mescape \
-        Geometry Delete Surfaces 1 escape Mescape \
-        'GetPointCoord Silent FNoJoin 0.2,0.2 escape Mescape \
-        Geometry Create Object CirclePNR 0.2 0.2 0.0 0.0 0.0 1.0 0.05 Mescape \
-        Geometry Delete Surfaces 1 escape escape Mescape \
-        Geometry Create Line 0.6,0.19 @-0.4,0 escape Join 6 NoJoin @0,0.02 @-0.4,0 escape escape escape escape escape Mescape \
-        Geometry Create IntMultLines 5 6 escape 8 10 escape escape escape escape Mescape \
-        Geometry Delete AllTypes points 7 9 lines 12 14 surfaces volumes dimensions points lines 15 surfaces volumes dimensions escape Mescape \
-        Geometry Create NurbsSurface 1 2 3 4 7 9 11 13 16 escape escape
+        GiD_Process 'Layers ChangeName Layer0 Fluid escape Mescape 
+        GiD_Process MEscape Geometry Create Object Rectangle 0,0 2.5,0.41 Mescape 
+        GiD_Process MEscape Geometry Delete Surfaces 1 escape Mescape \
+        'GetPointCoord Silent FNoJoin 0.2,0.2 escape escape 
+        GiD_Process MEscape Geometry Create Object CirclePNR 0.2 0.2 0.0 0.0 0.0 1.0 0.05 escape escape escape 
+        GiD_Process MEscape Geometry Delete Surfaces 1 escape escape  
+        GiD_Process MEscape Geometry Create Line 0.6,0.19 @-0.4,0 escape Join 6 NoJoin @0,0.02 @-0.4,0 escape escape escape escape escape  
+        GiD_Process MEscape Geometry Create IntMultLines 5 6 escape 8 10 escape escape escape escape  
+        GiD_Process MEscape Geometry Delete AllTypes points 7 9 lines 12 14 surfaces volumes dimensions points lines 15 surfaces volumes dimensions escape escape 
+        GiD_Process MEscape Geometry Create NurbsSurface 1 2 3 4 7 9 11 13 16 escape escape
     } else {
         # 3D version not implemented yet
     }
@@ -328,7 +328,7 @@ proc FSI::examples::TreeAssignationTurekBenchmark {args} {
     gid_groups_conds::setAttributesF {container[@n='FSI']/container[@n='Structural']/container[@n='StageInfo']/value[@n='SolutionType']} {v Dynamic}
 
     # Structural Parts
-    set structParts {container[@n='FSI']/container[@n='Structural']/condition[@n='Parts']}
+    set structParts {container[@n='FSI']/container[@n='Structural']/container[@n='Parts']/condition[@n='Parts_Solid']}
     set structPartsNode [customlib::AddConditionGroupOnXPath $structParts Structure]
     $structPartsNode setAttribute ov [expr {$nd == "3D" ? "volume" : "surface"}]
     set constLawNameStruc [expr {$nd == "3D" ? "KirchhoffSaintVenant3DLaw" : "KirchhoffSaintVenantPlaneStrain2DLaw"}]

--- a/kratos.gid/apps/FSI/xml/Main.spd
+++ b/kratos.gid/apps/FSI/xml/Main.spd
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-  
-    <container n="FSI" pn="FSI" icon="app" prefix="FSI" tree_state="open" open_window="0">
 
-        <container n="Fluid" pn="Fluid" icon="units" prefix="FL" tree_state="open" open_window="0">
-            <include n="AnalysisType" active="1" path="apps/Fluid/xml/AnalysisType.spd"/>
-            <include n="Parts" active="1" path="apps/Fluid/xml/Parts.spd"/>
-            <include n="InitialConditions" active="1" path="apps/Fluid/xml/InitialConditions.spd"/>
-            <include n="BoundaryConditions" active="1" path="apps/Fluid/xml/BoundaryConditions.spd"/>
-            <include n="SolutionStrategy" active="1" path="apps/FSI/xml/SolutionStrategyFluid.spd"/>
-            <include n="Results" active="1" path="apps/Common/xml/Results.spd" un="FLResults"/>
-            <include n="Materials" active="1" path="apps/Fluid/xml/Materials.spd"/>
-        </container>
-    
-        <container n="Structural" pn="Structure" icon="app" prefix="ST" tree_state="open" open_window="0">
-            <include n="StageInfo" active="1" path="apps/Structural/xml/StageInfo.spd"/>
-            <include n="Parts" active="1" path="apps/Structural/xml/Parts.spd"/>
-            <include n="BoundaryConditions" active="1" path="apps/Structural/xml/BoundaryConditions.spd"/>
-            <include n="Loads" active="1" path="apps/Structural/xml/Loads.spd" pn="Conditions"/>
-            <include n="SolutionStrategy" active="1" path="apps/FSI/xml/SolutionStrategyStructural.spd"/>
-            <include n="Results" active="1" path="apps/Common/xml/Results.spd"  un="STResults"/>
-            <include n="Materials" active="1" path="apps/Structural/xml/Materials.spd"/>
-        </container>
-    
-        <container n="FSI" pn="Coupling" icon="app" prefix="FSI" tree_state="open" open_window="0">
-            <include n="AnalysisType" active="1" path="apps/FSI/xml/AnalysisType.spd"/>
-            <include n="SolutionStrategy" active="1" path="apps/FSI/xml/SolutionStrategy.spd"/>
-            <include n="Intervals" active="1" path="apps/Common/xml/Intervals.spd"/>
-        </container>
-        
+<container n="FSI" pn="FSI" icon="app" prefix="FSI" tree_state="open" open_window="0">
+
+    <container n="Fluid" pn="Fluid" icon="units" prefix="FL" tree_state="open" open_window="0">
+        <include n="AnalysisType" active="1" path="apps/Fluid/xml/AnalysisType.spd"/>
+        <include n="Parts" active="1" path="apps/Fluid/xml/Parts.spd"/>
+        <include n="InitialConditions" active="1" path="apps/Fluid/xml/InitialConditions.spd"/>
+        <include n="BoundaryConditions" active="1" path="apps/Fluid/xml/BoundaryConditions.spd"/>
+        <include n="SolutionStrategy" active="1" path="apps/FSI/xml/SolutionStrategyFluid.spd"/>
+        <include n="Results" active="1" path="apps/Common/xml/Results.spd" un="FLResults"/>
+        <include n="Materials" active="1" path="apps/Fluid/xml/Materials.spd"/>
     </container>
+
+    <container n="Structural" pn="Structure" icon="app" prefix="ST" tree_state="open" open_window="0">
+        <include n="StageInfo" active="1" path="apps/Structural/xml/StageInfo.spd"/>
+        <include n="Parts" active="1" path="apps/Structural/xml/Parts.spd"/>
+        <include n="BoundaryConditions" active="1" path="apps/Structural/xml/BoundaryConditions.spd"/>
+        <include n="Loads" active="1" path="apps/Structural/xml/Loads.spd" pn="Conditions"/>
+        <include n="SolutionStrategy" active="1" path="apps/FSI/xml/SolutionStrategyStructural.spd"/>
+        <include n="Results" active="1" path="apps/Common/xml/Results.spd" un="STResults"/>
+        <include n="Materials" active="1" path="apps/Structural/xml/Materials.spd"/>
+    </container>
+
+    <container n="FSI" pn="Coupling" icon="app" prefix="FSI" tree_state="open" open_window="0">
+        <include n="AnalysisType" active="1" path="apps/FSI/xml/AnalysisType.spd"/>
+        <include n="SolutionStrategy" active="1" path="apps/FSI/xml/SolutionStrategy.spd"/>
+        <include n="Intervals" active="1" path="apps/Common/xml/Intervals.spd"/>
+    </container>
+
+</container>

--- a/kratos.gid/apps/FSI/xml/Procs.spd
+++ b/kratos.gid/apps/FSI/xml/Procs.spd
@@ -89,25 +89,6 @@
 	  
 	  ]]>
 	</proc>
-		  			
-		  <proc n='CheckNodalConditionStateSolid' args='args'>
-	  <![CDATA[
-	  # Overwritten the base function to add Solution Type restrictions
-		set parts_un STParts
-	    if {[spdAux::getRoute $parts_un] ne ""} {
-			set conditionId [$domNode @n]
-			set elems [$domNode selectNodes "[spdAux::getRoute $parts_un]/group/value\[@n='Element'\]"]
-			set elemnames [list ]
-			foreach elem $elems { lappend elemnames [$elem @v]}
-			set elemnames [lsort -unique $elemnames]
-			
-			set solutionType [get_domnode_attribute [$domNode selectNodes [spdAux::getRoute STSoluType]] v]
-			set params [list analysis_type $solutionType]
-			if {[::Model::CheckElementsNodalCondition $conditionId $elemnames $params]} {return "normal"} else {return "hidden"}
-		} {return "normal"}
-	  ]]>
-	</proc>		
-	  
 	          <proc n='CheckGeometryStructural' args='args'>
           <![CDATA[                
                 if {$::Model::SpatialDimension eq "3D"} {return surface,volume} {return surface}                
@@ -129,5 +110,11 @@
       return [Structural::xml::ProcCheckGeometrySolid $domNode $args]              
       ]]>
     </proc>
+	
+    <proc n='CheckNodalConditionStateStructural' args='args'>
+	  <![CDATA[
+	  return [Structural::xml::ProcCheckNodalConditionStateStructural $domNode $args]
+	  ]]>
+	</proc>		
 
 </container>

--- a/kratos.gid/apps/Structural/examples/HighRiseBuilding.tcl
+++ b/kratos.gid/apps/Structural/examples/HighRiseBuilding.tcl
@@ -69,7 +69,7 @@ proc Structural::examples::TreeAssignationHighRiseBuilding2D {args} {
     gid_groups_conds::setAttributesF {container[@n='Structural']/container[@n='StageInfo']/value[@n='SolutionType']} {v Dynamic}
 
     # Structural Parts
-    set structParts {container[@n='Structural']/condition[@n='Parts']}
+    set structParts {container[@n='Structural']/container[@n='Parts']/condition[@n='Parts_Solid']}
     set structPartsNode [customlib::AddConditionGroupOnXPath $structParts Structure]
     $structPartsNode setAttribute ov surface
     set constLawNameStruc "LinearElasticPlaneStress2DLaw"

--- a/kratos.gid/apps/Structural/examples/TrussCantilever.tcl
+++ b/kratos.gid/apps/Structural/examples/TrussCantilever.tcl
@@ -73,7 +73,7 @@ proc Structural::examples::TreeAssignationTrussCantilever {args} {
     # gid_groups_conds::setAttributesF {container[@n='FSI']/container[@n='Structural']/container[@n='StageInfo']/value[@n='SolutionType']} {v Dynamic}
 
     # Structural Parts
-    set structParts {container[@n='Structural']/condition[@n='Parts']}
+    set structParts {container[@n='Structural']/container[@n='Parts']/condition[@n='Parts_Truss']}
     set structPartsNode [customlib::AddConditionGroupOnXPath $structParts Structure]
     $structPartsNode setAttribute ov line
     set constLawNameStruc "TrussConstitutiveLaw"

--- a/kratos.gid/apps/Structural/write/write.tcl
+++ b/kratos.gid/apps/Structural/write/write.tcl
@@ -200,7 +200,7 @@ proc Structural::write::WriteMaterialsFile { } {
 }
 
 proc Structural::write::GetUsedElements { {get "Objects"} } {
-    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/group"
+    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/condition/group"
     set lista [list ]
     foreach gNode [[customlib::GetBaseRoot] selectNodes $xp1] {
         set elem_name [get_domnode_attribute [$gNode selectNodes ".//value\[@n='Element']"] v]
@@ -212,7 +212,7 @@ proc Structural::write::GetUsedElements { {get "Objects"} } {
 }
 
 proc Structural::write::writeLocalAxes { } {
-    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/group"
+    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/condition/group"
     foreach gNode [[customlib::GetBaseRoot] selectNodes $xp1] {
         set elem_name [get_domnode_attribute [$gNode selectNodes ".//value\[@n='Element']"] v]
         set e [Model::getElement $elem_name]

--- a/kratos.gid/apps/Structural/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/Structural/write/writeProjectParameters.tcl
@@ -230,7 +230,7 @@ proc Structural::write::writeParametersEvent { } {
 
 proc Structural::write::UsingRotationDofElements { } {
     set root [customlib::GetBaseRoot]
-    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/group/value\[@n='Element'\]"
+    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/condition/group/value\[@n='Element'\]"
     set elements [$root selectNodes $xp1]
     set bool false
     foreach element_node $elements {
@@ -243,7 +243,7 @@ proc Structural::write::UsingRotationDofElements { } {
 }
 proc Structural::write::UsingFileInPrestressedMembrane { } {
     set root [customlib::GetBaseRoot]
-    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/group/value\[@n='Element'\]"
+    set xp1 "[spdAux::getRoute [GetAttribute parts_un]]/condition/group/value\[@n='Element'\]"
     set elements [$root selectNodes $xp1]
     set found false
     foreach element_node $elements {

--- a/kratos.gid/apps/Structural/xml/Elements.xml
+++ b/kratos.gid/apps/Structural/xml/Elements.xml
@@ -2,7 +2,7 @@
 <ElementList>
   <!--solid elements-->
   <!--small displacements-->
-  <ElementItem n="SmallDisplacementElement2D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" AnalysisType="linear,non_linear" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement solid element">
+  <ElementItem n="SmallDisplacementElement2D" pn="Solid small displacements" ov="surface" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" AnalysisType="linear,non_linear" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement solid element">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="SmallDisplacementElement2D3N"/>
@@ -38,7 +38,7 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="SmallDisplacementElementAxisym" pn="Solid small displacements" ImplementedInFile="axisym_small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2Da" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements an axisymetric small displacement solid element" AnalysisType="linear,non_linear">
+  <ElementItem n="SmallDisplacementElementAxisym" pn="Solid small displacements" ov="surface" ImplementedInFile="axisym_small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2Da" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements an axisymetric small displacement solid element" AnalysisType="linear,non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="AxisymSmallDisplacementElement2D3N"/>
@@ -71,7 +71,7 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="SmallDisplacementElement3D" pn="Solid small displacements" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement solid element" AnalysisType="linear,non_linear">
+  <ElementItem n="SmallDisplacementElement3D" pn="Solid small displacements" ov="volume" ImplementedInFile="small_displacement.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement solid element" AnalysisType="linear,non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Tetrahedra" nodes="4" KratosName="SmallDisplacementElement3D4N"/>
@@ -108,7 +108,7 @@
     </outputs>
   </ElementItem>
   <!--Bbar elements-->
-  <ElementItem n="SmallDisplacementBbarElement2D" pn="Solid small displacements Bbar" ImplementedInFile="small_displacement_bbar.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement Bbar solid element" AnalysisType="linear,non_linear">
+  <ElementItem n="SmallDisplacementBbarElement2D" pn="Solid small displacements Bbar" ov="surface" ImplementedInFile="small_displacement_bbar.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement Bbar solid element" AnalysisType="linear,non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Quadrilateral" nodes="4" KratosName="SmallDisplacementBbarElement2D4N"/>
@@ -139,7 +139,7 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="SmallDisplacementBbarElement3D" pn="Solid small displacements Bbar" ImplementedInFile="small_displacement_bbar.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement Bbar solid element" AnalysisType="linear,non_linear">
+  <ElementItem n="SmallDisplacementBbarElement3D" pn="Solid small displacements Bbar" ov="volume" ImplementedInFile="small_displacement_bbar.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a small displacement Bbar solid element" AnalysisType="linear,non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Hexahedra" nodes="8" KratosName="SmallDisplacementBbarElement3D8N"/>
@@ -171,7 +171,7 @@
   </ElementItem>
   <!--large displacements-->
   <!--total lagrangian-->
-  <ElementItem n="TotalLagrangianElement2D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" help="This element it implements a Total Lagrangian approach to large deformation kinematics" AnalysisType="non_linear">
+  <ElementItem n="TotalLagrangianElement2D" pn="Solid total lagrangian" ov="surface" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" help="This element it implements a Total Lagrangian approach to large deformation kinematics" AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="TotalLagrangianElement2D3N"/>
@@ -204,7 +204,7 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="TotalLagrangianElement3D" pn="Solid total lagrangian" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a Total Lagrangian approach to large deformation kinematics" AnalysisType="non_linear">
+  <ElementItem n="TotalLagrangianElement3D" pn="Solid total lagrangian" ov="volume" ImplementedInFile="total_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a Total Lagrangian approach to large deformation kinematics" AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Tetrahedra" nodes="4" KratosName="TotalLagrangianElement3D4N"/>
@@ -240,7 +240,7 @@
     </outputs>
   </ElementItem>
   <!--updated lagrangian-->
-  <ElementItem n="UpdatedLagrangianElement2D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" help="This element it implements a Updated Lagrangian approach to large deformation kinematics" AnalysisType="non_linear">
+  <ElementItem n="UpdatedLagrangianElement2D" pn="Solid updated lagrangian" ov="surface" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="True,False" ElementType="Solid" help="This element it implements a Updated Lagrangian approach to large deformation kinematics" AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="UpdatedLagrangianElement2D3N"/>
@@ -273,7 +273,7 @@
       <parameter n="PK2_STRESS_TENSOR" pn="PK2 Stress Tensor" v="false" state="hidden"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="UpdatedLagrangianElement3D" pn="Solid updated lagrangian" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a Updated Lagrangian approach to large deformation kinematics" AnalysisType="non_linear">
+  <ElementItem n="UpdatedLagrangianElement3D" pn="Solid updated lagrangian" ov="volume" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="This element it implements a Updated Lagrangian approach to large deformation kinematics" AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Tetrahedra" nodes="4" KratosName="UpdatedLagrangianElement3D4N"/>
@@ -311,7 +311,7 @@
   <!--structural elements-->
   <!--shell elements-->
   <!--large displacements-->
-  <ElementItem n="ShellThinCorotationalElement" pn="Shell thin corotational" ImplementedInFile="shell_thin_element_3DxN.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" help="This element implements a corotational element for thin shells in a large displacements approach" ElementType="Shell" RotationDofs="True" AnalysisType="linear,non_linear">
+  <ElementItem n="ShellThinCorotationalElement" pn="Shell thin corotational" ov="surface" ImplementedInFile="shell_thin_element_3DxN.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" help="This element implements a corotational element for thin shells in a large displacements approach" ElementType="Shell" RotationDofs="True" AnalysisType="linear,non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="ShellThinElementCorotational3D3N"/>
@@ -349,7 +349,7 @@
       <parameter n="VON_MISES_STRESS_BOTTOM_SURFACE" pn="Von Mises stress - bottom surface" v="true" />
     </outputs>
   </ElementItem>
-  <ElementItem n="ShellThickCorotationalElement" pn="Shell thick corotational" ImplementedInFile="shell_thick_element_3DxN.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" help="This element implements a corotational element for thick shells in a large displacements approach" ElementType="Shell" RotationDofs="True" AnalysisType="linear,non_linear">
+  <ElementItem n="ShellThickCorotationalElement" pn="Shell thick corotational" ov="surface" ImplementedInFile="shell_thick_element_3DxN.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="True" LargeDeformation="True" help="This element implements a corotational element for thick shells in a large displacements approach" ElementType="Shell" RotationDofs="True" AnalysisType="linear,non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="ShellThickElementCorotational3D3N"/>
@@ -388,7 +388,7 @@
     </outputs>
   </ElementItem>
   <!--membrane elements-->
-  <ElementItem n="PrestressedMembraneElement" pn="Membrane prestressed" ImplementedInFile="prestress_membrane_element.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" help="This element it implements a membrane structural model" RotationDofs="False" ElementType="Membrane" AnalysisType="non_linear">
+  <ElementItem n="PrestressedMembraneElement" pn="Membrane prestressed" ov="surface" ImplementedInFile="prestress_membrane_element.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="2" RequiresLocalAxes="False" LargeDeformation="False" help="This element it implements a membrane structural model" RotationDofs="False" ElementType="Membrane" AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Triangle" nodes="3" KratosName="PreStressMembraneElement3D3N"/>
@@ -414,14 +414,15 @@
         <parameter n="PRESTRESS_AXIS_GLOBAL" pn="Projection direction" type="inline_vector" v="0,0,0" parent="rotational"/>
         <parameter n="PRESTRESS_AXIS_1_GLOBAL" pn="Projection direction 1" type="inline_vector" v="0,0,0" parent="planar"/>
         <parameter n="PRESTRESS_AXIS_2_GLOBAL" pn="Projection direction 2" type="inline_vector" v="0,0,0" parent="planar"/>
-        <parameter n="PROJECTION_TYPE_FILEPATH" pn="Projection file" type="tablefile" parent="file" v="- No file"/></parameter>
+        <parameter n="PROJECTION_TYPE_FILEPATH" pn="Projection file" type="tablefile" parent="file" v="- No file"/>
+      </parameter>
     </inputs>
     <outputs>
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor" />
     </outputs>
   </ElementItem>
   <!--beam elements-->
-  <ElementItem n="LinearBeamElement2D" pn="Beam small displacements" ImplementedInFile="small_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False" help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam" AnalysisType="linear,non_linear">
+  <ElementItem n="LinearBeamElement2D" pn="Beam small displacements" ov="line" ImplementedInFile="small_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False" help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam" AnalysisType="linear,non_linear">
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="CrLinearBeamElement2D2N"/>
     </TopologyFeatures>
@@ -444,7 +445,7 @@
       <parameter n="MOMENT" pn="Moment"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="BeamElement2D" pn="Beam large displacements" ImplementedInFile="large_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False" help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam" AnalysisType="non_linear">
+  <ElementItem n="BeamElement2D" pn="Beam large displacements" ov="line" ImplementedInFile="large_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False" help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam" AnalysisType="non_linear">
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="CrBeamElement2D2N"/>
     </TopologyFeatures>
@@ -467,7 +468,7 @@
       <parameter n="MOMENT" pn="Moment"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="LinearBeamElement3D" pn="Beam small displacements" ImplementedInFile="small_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="True" LocalAxesAutomaticFunction="Structural::xml::AddLocalAxesToBeamElement" LargeDeformation="False" help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam" AnalysisType="linear,non_linear">
+  <ElementItem n="LinearBeamElement3D" pn="Beam small displacements" ov="line" ImplementedInFile="small_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="True" LocalAxesAutomaticFunction="Structural::xml::AddLocalAxesToBeamElement" LargeDeformation="False" help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam" AnalysisType="linear,non_linear">
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="CrLinearBeamElement3D2N"/>
     </TopologyFeatures>
@@ -490,7 +491,7 @@
       <parameter n="MOMENT" pn="Moment"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="BeamElement3D" pn="Beam large displacements" ImplementedInFile="large_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="True" LocalAxesAutomaticFunction="Structural::xml::AddLocalAxesToBeamElement" LargeDeformation="False" help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam" AnalysisType="non_linear">
+  <ElementItem n="BeamElement3D" pn="Beam large displacements" ov="line" ImplementedInFile="large_displacement_beam_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="True" LocalAxesAutomaticFunction="Structural::xml::AddLocalAxesToBeamElement" LargeDeformation="False" help="This element implements a small displacement timoshenko beam structural model" RotationDofs="True" ElementType="Beam" AnalysisType="non_linear">
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="CrBeamElement3D2N"/>
     </TopologyFeatures>
@@ -514,7 +515,7 @@
     </outputs>
   </ElementItem>
   <!--truss elements-->
-  <ElementItem n="TrussLinearElement2D" pn="Truss small displacements" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False" help="This element implements a small displacements truss" RotationDofs="False" ElementType="Truss" AnalysisType="linear,non_linear">
+  <ElementItem n="TrussLinearElement2D" pn="Truss small displacements" ov="line" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False" help="This element implements a small displacements truss" RotationDofs="False" ElementType="Truss" AnalysisType="linear,non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="TrussLinearElement3D2N"/>
@@ -538,7 +539,7 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="TrussElement2D" pn="Truss large displacements" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss" AnalysisType="non_linear">
+  <ElementItem n="TrussElement2D" pn="Truss large displacements" ov="line" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss" AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="TrussElement3D2N"/>
@@ -562,7 +563,7 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="TrussLinearElement3D" pn="Truss small displacements" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False" help="This element implements a small displacements truss" RotationDofs="False" ElementType="Truss" AnalysisType="linear,non_linear">
+  <ElementItem n="TrussLinearElement3D" pn="Truss small displacements" ov="line" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="False" help="This element implements a small displacements truss" RotationDofs="False" ElementType="Truss" AnalysisType="linear,non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="TrussLinearElement3D2N"/>
@@ -586,7 +587,7 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="TrussElement3D" pn="Truss large displacements" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss" AnalysisType="non_linear">
+  <ElementItem n="TrussElement3D" pn="Truss large displacements" ov="line" ImplementedInFile="truss_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements truss" RotationDofs="False" ElementType="Truss" AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="TrussElement3D2N"/>
@@ -611,7 +612,7 @@
     </outputs>
   </ElementItem>
   <!--cable elements-->
-  <ElementItem n="CableElement2D" pn="Cable large displacements" ImplementedInFile="cable_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements cable" RotationDofs="False" ElementType="Cable" AnalysisType="non_linear">
+  <ElementItem n="CableElement2D" pn="Cable large displacements" ov="line" ImplementedInFile="cable_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements cable" RotationDofs="False" ElementType="Cable" AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="CableElement3D2N"/>
@@ -635,7 +636,7 @@
       <parameter n="CAUCHY_STRESS_TENSOR" pn="Cauchy stress tensor"/>
     </outputs>
   </ElementItem>
-  <ElementItem n="CableElement3D" pn="Cable large displacements" ImplementedInFile="cable_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements cable" RotationDofs="False" ElementType="Cable" AnalysisType="non_linear">
+  <ElementItem n="CableElement3D" pn="Cable large displacements" ov="line" ImplementedInFile="cable_element_3D2N.cpp" ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="1" RequiresLocalAxes="False" LargeDeformation="True" help="This element implements a large displacements cable" RotationDofs="False" ElementType="Cable" AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Line" nodes="2" KratosName="CableElement3D2N"/>

--- a/kratos.gid/apps/Structural/xml/GetFromXML.tcl
+++ b/kratos.gid/apps/Structural/xml/GetFromXML.tcl
@@ -80,7 +80,7 @@ proc Structural::xml::ProcGetSolutionStrategiesStructural { domNode args } {
     return $pnames
 }
 
-proc Structural::xml::ProcCheckNodalConditionStateSolid {domNode args} {
+proc Structural::xml::ProcCheckNodalConditionStateStructural {domNode args} {
     # Overwritten the base function to add Solution Type restrictions
     set parts_un STParts
     if {[spdAux::getRoute $parts_un] ne ""} {
@@ -90,7 +90,7 @@ proc Structural::xml::ProcCheckNodalConditionStateSolid {domNode args} {
         if {$cnd_dim ne ""} {
             if {$cnd_dim ne $Model::SpatialDimension} {return "hidden"}
         }
-        set elems [$domNode selectNodes "[spdAux::getRoute $parts_un]/group/value\[@n='Element'\]"]
+        set elems [$domNode selectNodes "[spdAux::getRoute $parts_un]/condition/group/value\[@n='Element'\]"]
         set elemnames [list ]
         foreach elem $elems { lappend elemnames [$elem @v]}
         set elemnames [lsort -unique $elemnames]

--- a/kratos.gid/apps/Structural/xml/NodalConditions.xml
+++ b/kratos.gid/apps/Structural/xml/NodalConditions.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <NodalConditionList>
   <NodalConditionItem n="DISPLACEMENT" pn="Displacement" ProcessName="AssignVectorVariableProcess" VariableName="DISPLACEMENT" ImplementedInApplication="StructuralMechanicsApplication"
-		      analysis_type="Static,Quasi-static,Dynamic,eigen_value,formfinding"  unit_magnitude="L" units="m" App="Structural" state="CheckNodalConditionStateSolid" Interval="Total">
+		      analysis_type="Static,Quasi-static,Dynamic,eigen_value,formfinding"  unit_magnitude="L" units="m" App="Structural" state="CheckNodalConditionStateStructural" Interval="Total">
     <outputs>
       <parameter n="REACTION" pn="Reaction" v="Yes"/>
     </outputs>
   </NodalConditionItem>
 
   <NodalConditionItem n="VELOCITY" pn="Velocity" ProcessName="AssignVectorVariableProcess" VariableName="VELOCITY" ImplementedInApplication="StructuralMechanicsApplication"
-		      analysis_type="Dynamic,formfinding" unit_magnitude="Velocity" units="m/s" App="Structural" state="CheckNodalConditionStateSolid" Interval="Total">
+		      analysis_type="Dynamic,formfinding" unit_magnitude="Velocity" units="m/s" App="Structural" state="CheckNodalConditionStateStructural" Interval="Total">
   </NodalConditionItem>
 
   <NodalConditionItem  n="ACCELERATION" pn="Acceleration" ProcessName="AssignVectorVariableProcess" VariableName="ACCELERATION" ImplementedInApplication="StructuralMechanicsApplication"
-		       analysis_type="Dynamic,formfinding" unit_magnitude="Acceleration" units="m/s^2" App="Structural" state="CheckNodalConditionStateSolid" Interval="Total">
+		       analysis_type="Dynamic,formfinding" unit_magnitude="Acceleration" units="m/s^2" App="Structural" state="CheckNodalConditionStateStructural" Interval="Total">
   </NodalConditionItem>
 
   <NodalConditionItem  n="PRESSURE" pn="Pressure" ProcessName="AssignScalarVariableProcess" VariableName="PRESSURE" ImplementedInApplication="StructuralMechanicsApplication"
-		       analysis_type="Static,Quasi-static,Dynamic,eigen_value,formfinding"  unit_magnitude="P"  units="Pa" v="Yes" App="Structural" state="CheckNodalConditionStateSolid" Interval="Total">
+		       analysis_type="Static,Quasi-static,Dynamic,eigen_value,formfinding"  unit_magnitude="P"  units="Pa" v="Yes" App="Structural" state="CheckNodalConditionStateStructural" Interval="Total">
   </NodalConditionItem>
   <NodalConditionItem  n="CONTACT" pn="Contact master" ProcessName="ALMContactProcess" VariableName="" ImplementedInApplication="ContactStructuralMechanicsApplication"
 		       analysis_type="Static,Quasi-static,Dynamic,eigen_value"  App="Structural" state="" Interval="Total"  ov="[CheckGeometry 2]"  ProductionReady="Developer">
@@ -25,13 +25,13 @@
 		       analysis_type="Static,Quasi-static,Dynamic,eigen_value"  App="Structural" state="" Interval="False"  ov="[CheckGeometry 2]"  ProductionReady="Developer">
   </NodalConditionItem>
   <NodalConditionItem n="ROTATION" pn="Rotation" ProcessName="AssignVectorVariableProcess" App="Structural" ImplementedInApplication="StructuralMechanicsApplication"
-					  analysis_type="Static,Quasi-static,Dynamic,eigen_value,formfinding" unit_magnitude="Angle" units="rad" VariableName="ROTATION" state="CheckNodalConditionStateSolid" Interval="Total">
+					  analysis_type="Static,Quasi-static,Dynamic,eigen_value,formfinding" unit_magnitude="Angle" units="rad" VariableName="ROTATION" state="CheckNodalConditionStateStructural" Interval="Total">
     <outputs>
       <parameter n="REACTION_MOMENT" pn="Moment reaction" v="Yes"/>
     </outputs>
   </NodalConditionItem>
-  <NodalConditionItem n="ANGULAR_VELOCITY" pn="Angular Velocity" ProcessName="AssignVectorVariableProcess" state="CheckNodalConditionStateSolid" Interval="Total" analysis_type="Dynamic" unit_magnitude="Angle/T" units="rad/s" VariableName="ANGULAR_VELOCITY" App="Structural" ImplementedInApplication="StructuralMechanicsApplication"></NodalConditionItem>
-  <NodalConditionItem n="ANGULAR_ACCELERATION" pn="Angular Acceleration" ProcessName="AssignVectorVariableProcess" state="CheckNodalConditionStateSolid" Interval="Total" analysis_type="Dynamic" unit_magnitude="Angle/T^2" units="rad/s^2" VariableName="ANGULAR_ACCELERATION" App="Structural" ImplementedInApplication="StructuralMechanicsApplication"></NodalConditionItem>
-  <NodalConditionItem n="CONDENSED_DOF_LIST_2D" pn="Hinge" ov="line" ProcessName="HingesStaticCondensation2DProcess" state="CheckNodalConditionStateSolid" WorkingSpaceDimension="2D" Interval="False" analysis_type="Static,Quasi-static,Dynamic" VariableName="CONDENSED_DOF_LIST" App="Structural" ImplementedInApplication="StructuralMechanicsApplication"></NodalConditionItem>
-  <NodalConditionItem n="CONDENSED_DOF_LIST" pn="Hinge" ov="line" ProcessName="HingesStaticCondensationProcess" state="CheckNodalConditionStateSolid" WorkingSpaceDimension="3D" Interval="False" analysis_type="Static,Quasi-static,Dynamic" VariableName="CONDENSED_DOF_LIST" App="Structural" ImplementedInApplication="StructuralMechanicsApplication"></NodalConditionItem>
+  <NodalConditionItem n="ANGULAR_VELOCITY" pn="Angular Velocity" ProcessName="AssignVectorVariableProcess" state="CheckNodalConditionStateStructural" Interval="Total" analysis_type="Dynamic" unit_magnitude="Angle/T" units="rad/s" VariableName="ANGULAR_VELOCITY" App="Structural" ImplementedInApplication="StructuralMechanicsApplication"></NodalConditionItem>
+  <NodalConditionItem n="ANGULAR_ACCELERATION" pn="Angular Acceleration" ProcessName="AssignVectorVariableProcess" state="CheckNodalConditionStateStructural" Interval="Total" analysis_type="Dynamic" unit_magnitude="Angle/T^2" units="rad/s^2" VariableName="ANGULAR_ACCELERATION" App="Structural" ImplementedInApplication="StructuralMechanicsApplication"></NodalConditionItem>
+  <NodalConditionItem n="CONDENSED_DOF_LIST_2D" pn="Hinge" ov="line" ProcessName="HingesStaticCondensation2DProcess" state="CheckNodalConditionStateStructural" WorkingSpaceDimension="2D" Interval="False" analysis_type="Static,Quasi-static,Dynamic" VariableName="CONDENSED_DOF_LIST" App="Structural" ImplementedInApplication="StructuralMechanicsApplication"></NodalConditionItem>
+  <NodalConditionItem n="CONDENSED_DOF_LIST" pn="Hinge" ov="line" ProcessName="HingesStaticCondensationProcess" state="CheckNodalConditionStateStructural" WorkingSpaceDimension="3D" Interval="False" analysis_type="Static,Quasi-static,Dynamic" VariableName="CONDENSED_DOF_LIST" App="Structural" ImplementedInApplication="StructuralMechanicsApplication"></NodalConditionItem>
 </NodalConditionList>

--- a/kratos.gid/apps/Structural/xml/Parts.spd
+++ b/kratos.gid/apps/Structural/xml/Parts.spd
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<condition n="Parts" pn="Parts" ov="[CheckGeometrySolid]" ovm="element" icon="shells16" help="Select your group" un="STParts" update_proc="UpdateParts">
+<container  n="Parts" pn="Parts" un="STParts" icon="shells16" >
+	<dynamicnode command="spdAux::injectPartsByElementType" args="ImplementedInApplication StructuralMechanicsApplication"/>
+</container>
+<!-- <condition n="Parts" pn="Parts" ov="[CheckGeometrySolid]" ovm="element" icon="shells16" help="Select your group" un="STParts" update_proc="UpdateParts">
 	  <value n="Element" pn="Element" actualize_tree="1" values="" v="" dict="[GetElements]" state="normal" >
 			<dependencies node="../value" actualize="1" />
 	  </value>
@@ -13,4 +16,4 @@
 			<dependencies node="../value" actualize="1"/>
 	  </value>
 	  <dynamicnode command="spdAux::injectPartInputs" args=""/>
-</condition>
+</condition> -->

--- a/kratos.gid/apps/Structural/xml/Procs.spd
+++ b/kratos.gid/apps/Structural/xml/Procs.spd
@@ -7,9 +7,9 @@
 	  ]]>
 	</proc>
 		  			
-    <proc n='CheckNodalConditionStateSolid' args='args'>
+    <proc n='CheckNodalConditionStateStructural' args='args'>
 	  <![CDATA[
-	  return [Structural::xml::ProcCheckNodalConditionStateSolid $domNode $args]
+	  return [Structural::xml::ProcCheckNodalConditionStateStructural $domNode $args]
 	  ]]>
 	</proc>		
 

--- a/kratos.gid/scripts/Controllers/TreeInjections.tcl
+++ b/kratos.gid/scripts/Controllers/TreeInjections.tcl
@@ -814,8 +814,8 @@ proc spdAux::injectPartsByElementType {domNode args} {
         set ov [spdAux::GetElementsCommonPropertyValues [dict get $element_types $element_type] ov]
         set ovm "element"
         if {[lsearch $ov point] != -1 && [lsearch $ov Point] != -1 } {set ovm "node,element"}
-        set condition_string "<condition n=\"Parts_${element_type}\" pn=\"Parts ${element_type}\" ov=\"$ov\" ovm=\"$ovm\" icon=\"shells16\" help=\"Select your group\" update_proc=\"UpdateParts\">
-            <value n=\"Element\" pn=\"Element\" actualize_tree=\"1\" values=\"\" v=\"\" dict=\"\[GetElements\]\" state=\"normal\" >
+        set condition_string "<condition n=\"Parts_${element_type}\" pn=\"${element_type}\" ov=\"$ov\" ovm=\"$ovm\" icon=\"shells16\" help=\"Select your group\" update_proc=\"UpdateParts\">
+            <value n=\"Element\" pn=\"Element\" actualize_tree=\"1\" values=\"\" v=\"\" dict=\"\[GetElements ElementType $element_type\]\" state=\"normal\" >
                     <dependencies node=\"../value\" actualize=\"1\" />
             </value>
             <value n=\"ConstitutiveLaw\" pn=\"Constitutive law\" v=\"\" actualize_tree=\"1\"

--- a/kratos.gid/scripts/Controllers/TreeInjections.tcl
+++ b/kratos.gid/scripts/Controllers/TreeInjections.tcl
@@ -801,10 +801,11 @@ proc spdAux::ClearCutPlanes { {cut_planes_un CutPlanes} } {
     }
 
 }
+
 proc spdAux::injectPartsByElementType {domNode args} {
     set element_types [dict create]
 
-    foreach element [Model::GetElements] {
+    foreach element [Model::GetElements {*}$args] {
         if {[$element hasAttribute ElementType]} {
             dict lappend element_types [$element getAttribute ElementType] $element
         }

--- a/kratos.gid/scripts/Controllers/TreeInjections.tcl
+++ b/kratos.gid/scripts/Controllers/TreeInjections.tcl
@@ -801,3 +801,52 @@ proc spdAux::ClearCutPlanes { {cut_planes_un CutPlanes} } {
     }
 
 }
+proc spdAux::injectPartsByElementType {domNode args} {
+    set element_types [dict create]
+
+    foreach element [Model::GetElements] {
+        if {[$element hasAttribute ElementType]} {
+            dict lappend element_types [$element getAttribute ElementType] $element
+        }
+    }
+
+    foreach element_type [dict keys $element_types] {
+        set ov [spdAux::GetElementsCommonPropertyValues [dict get $element_types $element_type] ov]
+        set ovm "element"
+        if {[lsearch $ov point] != -1 && [lsearch $ov Point] != -1 } {set ovm "node,element"}
+        set condition_string "<condition n=\"Parts_${element_type}\" pn=\"Parts ${element_type}\" ov=\"$ov\" ovm=\"$ovm\" icon=\"shells16\" help=\"Select your group\" update_proc=\"UpdateParts\">
+            <value n=\"Element\" pn=\"Element\" actualize_tree=\"1\" values=\"\" v=\"\" dict=\"\[GetElements\]\" state=\"normal\" >
+                    <dependencies node=\"../value\" actualize=\"1\" />
+            </value>
+            <value n=\"ConstitutiveLaw\" pn=\"Constitutive law\" v=\"\" actualize_tree=\"1\"
+                    values=\"\[GetConstitutiveLaws\]\" dict=\"\[GetAllConstitutiveLaws\]\">
+                    <dependencies node=\"../value\" actualize=\"1\"/>
+            </value>
+            <value n=\"Material\" pn=\"Material\" editable='0' help=\"Choose a material from the database\" update_proc=\"CambioMat\"
+                    values_tree='\[give_materials_list\]' v=\"Steel\" actualize_tree=\"1\" state=\"normal\">
+                    <edit_command n=\"Update material data\" pn=\"Update material data\" icon=\"refresh\" proc='edit_database_list'/>
+                    <dependencies node=\"../value\" actualize=\"1\"/>
+            </value>
+            <dynamicnode command=\"spdAux::injectPartInputs\" args=\"\"/>
+        </condition>"
+        set base [$domNode parent]
+        $base appendXML $condition_string
+        set orig [$base lastChild]
+        set new [$orig cloneNode -deep]
+        $orig delete
+        $base insertBefore $new $domNode
+    }
+    
+    $domNode delete
+    customlib::UpdateDocument
+    spdAux::processDynamicNodes $base
+}
+
+proc spdAux::GetElementsCommonPropertyValues {elements prop} {
+    set vals [list ]
+    foreach element $elements {
+        lappend vals [$element getAttribute $prop]
+    }
+    return [lsort -unique $vals]
+}
+

--- a/kratos.gid/scripts/Writing/WriteElements.tcl
+++ b/kratos.gid/scripts/Writing/WriteElements.tcl
@@ -4,6 +4,9 @@ proc write::writeElementConnectivities { } {
     set root [customlib::GetBaseRoot]
 
     set xp1 "[spdAux::getRoute $parts]/group"
+    if {[llength [$root selectNodes $xp1]] < 1} {
+        set xp1 "[spdAux::getRoute $parts]/condition/group"
+    }
     foreach gNode [$root selectNodes $xp1] {
         set elem [write::getValueByNode [$gNode selectNodes ".//value\[@n='Element']"] ]
         write::writeGroupElementConnectivities $gNode $elem

--- a/kratos.gid/scripts/Writing/WriteMaterials.tcl
+++ b/kratos.gid/scripts/Writing/WriteMaterials.tcl
@@ -7,6 +7,9 @@ proc write::processMaterials { {alt_path ""} {last_assigned_id -1}} {
     set root [customlib::GetBaseRoot]
 
     set xp1 "[spdAux::getRoute $parts]/group"
+    if {[llength [$root selectNodes $xp1]] < 1} {
+        set xp1 "[spdAux::getRoute $parts]/condition/group"
+    }
     if {$alt_path ne ""} {
         set xp1 $alt_path
     }

--- a/kratos.gid/scripts/Writing/Writing.tcl
+++ b/kratos.gid/scripts/Writing/Writing.tcl
@@ -621,7 +621,6 @@ proc write::getPropertiesList {parts_un {write_claw_name "True"} {model_part_nam
     if {[llength [$root selectNodes $xp1]] < 1} {
         set xp1 "[spdAux::getRoute $parts_un]/condition/group"
     }
-    W [$root selectNodes $xp1]
     foreach gNode [$root selectNodes $xp1] {
         set group [get_domnode_attribute $gNode n]
         set sub_model_part [write::getSubModelPartId Parts $group]

--- a/kratos.gid/scripts/Writing/Writing.tcl
+++ b/kratos.gid/scripts/Writing/Writing.tcl
@@ -365,6 +365,9 @@ proc write::getPartsGroupsId {} {
 
     set listOfGroups [list ]
     set xp1 "[spdAux::getRoute [GetConfigurationAttribute parts_un]]/group"
+    if {[llength [$root selectNodes $xp1]] < 1} {
+        set xp1 "[spdAux::getRoute [GetConfigurationAttribute parts_un]]/condition/group"
+    }
     set groups [$root selectNodes $xp1]
 
     foreach group $groups {
@@ -615,6 +618,10 @@ proc write::getPropertiesList {parts_un {write_claw_name "True"} {model_part_nam
     #set root [customlib::GetBaseRoot]
 
     set xp1 "[spdAux::getRoute $parts_un]/group"
+    if {[llength [$root selectNodes $xp1]] < 1} {
+        set xp1 "[spdAux::getRoute $parts_un]/condition/group"
+    }
+    W [$root selectNodes $xp1]
     foreach gNode [$root selectNodes $xp1] {
         set group [get_domnode_attribute $gNode n]
         set sub_model_part [write::getSubModelPartId Parts $group]


### PR DESCRIPTION
I've been working in the assignation of parts of the Structural application
Until now, it was a little bit confusing, as it's explained in the following example. The user didn't know which geometry type was available for each element, and the different elements were mixed in the 'Element' dropdown.

Thes PR improves the UX by grouping the elements in families, so the shells will be together, the beams, the membranes...

### Before
![image](https://user-images.githubusercontent.com/5918085/61475577-69145800-a98b-11e9-83db-b25cc39b3653.png)
All you can see, all the elements are in the same dropdown, and the user must select the geometry type (line, surface, volume) to set the assignation.
Since each element type in this app can only be assigned to a single geometry type, this is a non-sense. Membranes are only available for surfaces, cables to lines....

### New
![image](https://user-images.githubusercontent.com/5918085/61475772-d7591a80-a98b-11e9-869a-b8072a694a3b.png)
Now, the user 'double-clicks' on Parts > Shells (the element family) and only the shell elements are available in the dropdown. In addition, it can only select surfaces.

I think this is a cleaner design and hope you like it!
Of course, Structural app is being a pioneer. This solution can be easily implemented to any app with the same problem (Fluid dynamic does not need it since the y only have 1 element).

@KratosMultiphysics/structural-mechanics 
@KratosMultiphysics/technical-committee 