### PR TITLE
Reduce large number of parameters in conditions window

### DIFF
--- a/kratos.gid/apps/DEM/xml/Processes.xml
+++ b/kratos.gid/apps/DEM/xml/Processes.xml
@@ -5,107 +5,107 @@
 <Process n="DEM-FEM-Wall-Process" pn="Impose vector value by direction process" python_module="assign_vector_by_direction_to_condition_process" kratos_module="KratosMultiphysics" help="This process fixes all the components of a given vector variable" check="DirectorVectorNonZero direction">
   <inputs>
     <parameter n="SetActive"            type="bool"         pn="Activate"       v="true"     help="Set Yes to activate the group">
-      <parameter n="DEM-ImposedMotion"  parent="true"       pn="Type of Motion" type="combo"  v="None" values="None,LinearPeriodic,FreeMotion" pvalues="None,Linear-Periodic,Free motion" help="Set Yes to impose a predefined motion to the group">
-        <parameter n="Mass"             parent="FreeMotion" pn="Mass"           type="double" v="1.0"                  units="Kg"     unit_magnitude="M"/>
-        <parameter n="CenterOfMass"     parent="FreeMotion" pn="Center of mass" type="inline_vector"   v="0.0,0.0,0.0" units="m"      unit_magnitude="L"/>
-        <parameter n="Inertia"          parent="FreeMotion" pn="Inertia(Kg*m2)" type="inline_vector"   v="1.0,1.0,1.0" units="Kg*m^2" unit_magnitude="Inertia"/>
+      <parameter n="DEM-ImposedMotion"  parent="true"       pn="Type of Motion" type="combo"  v="None" values="None,LinearPeriodic,FreeMotion" pvalues="None,Linear-Periodic,Free motion" help="Set Yes to impose a predefined motion to the group" show_in_window="0">
+        <parameter n="Mass"             parent="FreeMotion" pn="Mass"           type="double" v="1.0"                  units="Kg"     unit_magnitude="M" show_in_window="0"/>
+        <parameter n="CenterOfMass"     parent="FreeMotion" pn="Center of mass" type="inline_vector"   v="0.0,0.0,0.0" units="m"      unit_magnitude="L" show_in_window="0"/>
+        <parameter n="Inertia"          parent="FreeMotion" pn="Inertia(Kg*m2)" type="inline_vector"   v="1.0,1.0,1.0" units="Kg*m^2" unit_magnitude="Inertia" show_in_window="0"/>
 
-        <parameter n="DEM-DOFS"         parent="FreeMotion"     type="combo"  v="No"    pn="Degrees of Freedom"     values="No,Yes"                 pvalues="No,Yes">
-          <parameter n="Ax"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Velocity X"         values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Velocity X">
-           <parameter n="Vx"             parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Velocity" units="m/s" help="X Velocity"/>
-           <parameter n="FilenameVx"     parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="X Velocity file"/> </parameter>
-          <parameter n="Ay"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Velocity Y"         values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Velocity Y">
-           <parameter n="Vy"             parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Velocity" units="m/s" help="Y Velocity"/>
-           <parameter n="FilenameVy"     parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="Y Velocity file"/> </parameter>
-          <parameter n="Az"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Velocity Z"         values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Velocity Z">
-           <parameter n="Vz"             parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Velocity" units="m/s" help="Z Velocity"/>
-           <parameter n="FilenameVz"     parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="Z Velocity file"/> </parameter>
-          <parameter n="Bx"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Angular Velocity X" values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Angular Velocity X">
-           <parameter n="AVx"            parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Angle/T" units="rad/s" help="X Angular Velocity"/>
-           <parameter n="FilenameAVx"    parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="X AVelocity file"/> </parameter>
-          <parameter n="By"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Angular Velocity Y" values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Angular Velocity Y">
-           <parameter n="AVy"            parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Angle/T" units="rad/s" help="Y Angular Velocity"/>
-           <parameter n="FilenameAVy"    parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="Y AVelocity file"/> </parameter>
-          <parameter n="Bz"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Angular Velocity Z" values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Angular Velocity Z">
-           <parameter n="AVz"            parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Angle/T" units="rad/s" help="Z Angular Velocity"/>
-           <parameter n="FilenameAVz"    parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="Z AVelocity file"/> </parameter>
-          <parameter n="VStart"         parent="FreeMotion,Yes"               v="0.0"   pn="Start time"             unit_magnitude="T" units="s"/>
-          <parameter n="VEnd"           parent="FreeMotion,Yes"               v="100.0" pn="End time"               unit_magnitude="T" units="s"/>
+        <parameter n="DEM-DOFS"         parent="FreeMotion"     type="combo"  v="No"    pn="Degrees of Freedom"     values="No,Yes"                 pvalues="No,Yes" show_in_window="0">
+          <parameter n="Ax"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Velocity X"         values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Velocity X" show_in_window="0">
+           <parameter n="Vx"             parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Velocity" units="m/s" help="X Velocity" show_in_window="0"/>
+           <parameter n="FilenameVx"     parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="X Velocity file" show_in_window="0"/> </parameter>
+          <parameter n="Ay"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Velocity Y"         values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Velocity Y" show_in_window="0">
+           <parameter n="Vy"             parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Velocity" units="m/s" help="Y Velocity" show_in_window="0"/>
+           <parameter n="FilenameVy"     parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="Y Velocity file" show_in_window="0"/> </parameter>
+          <parameter n="Az"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Velocity Z"         values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Velocity Z" show_in_window="0">
+           <parameter n="Vz"             parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Velocity" units="m/s" help="Z Velocity" show_in_window="0"/>
+           <parameter n="FilenameVz"     parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="Z Velocity file" show_in_window="0"/> </parameter>
+          <parameter n="Bx"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Angular Velocity X" values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Angular Velocity X" show_in_window="0">
+           <parameter n="AVx"            parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Angle/T" units="rad/s" help="X Angular Velocity" show_in_window="0"/>
+           <parameter n="FilenameAVx"    parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="X AVelocity file" show_in_window="0"/> </parameter>
+          <parameter n="By"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Angular Velocity Y" values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Angular Velocity Y" show_in_window="0">
+           <parameter n="AVy"            parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Angle/T" units="rad/s" help="Y Angular Velocity" show_in_window="0"/>
+           <parameter n="FilenameAVy"    parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="Y AVelocity file" show_in_window="0"/> </parameter>
+          <parameter n="Bz"             parent="FreeMotion,Yes" type="combo"  v="No"    pn="Fix Angular Velocity Z" values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Fix Angular Velocity Z" show_in_window="0">
+           <parameter n="AVz"            parent="Constant"                    v="0.0"   pn="   Value"               unit_magnitude="Angle/T" units="rad/s" help="Z Angular Velocity" show_in_window="0"/>
+           <parameter n="FilenameAVz"    parent="FromATable"    type="file"   v="- No file -"  pn="   Filename"  help="Z AVelocity file" show_in_window="0"/> </parameter>
+          <parameter n="VStart"         parent="FreeMotion,Yes"               v="0.0"   pn="Start time"             unit_magnitude="T" units="s" show_in_window="0"/>
+          <parameter n="VEnd"           parent="FreeMotion,Yes"               v="100.0" pn="End time"               unit_magnitude="T" units="s" show_in_window="0"/>
         </parameter>
 
-        <parameter n="DEM-InitialVelocities"  parent="FreeMotion"      v="No"    pn="Initial Velocities"             type="combo"  values="No,Yes">
-          <parameter n="iAx"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Velocity X"         type="bool"   help="Set Initial Velocity X">
-           <parameter n="iVx"                   parent="true"          v="0.0"   pn="   Value"           unit_magnitude="Velocity" units="m/s" help="X Velocity"/></parameter>
-          <parameter n="iAy"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Velocity Y"         type="bool"   help="Set Initial Velocity Y">
-           <parameter n="iVy"                   parent="true"          v="0.0"   pn="   Value"           unit_magnitude="Velocity" units="m/s" help="Y Velocity"/></parameter>
-          <parameter n="iAz"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Velocity Z"         type="bool"   help="Set Initial Velocity Z">
-           <parameter n="iVz"                   parent="true"          v="0.0"   pn="   Value"           unit_magnitude="Velocity" units="m/s" help="Z Velocity"/></parameter>
-          <parameter n="iBx"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Angular Velocity X" type="bool"   help="Set Initial Ang Velocity X">
-           <parameter n="iAVx"                  parent="true"          v="0.0"   pn="   Value"         unit_magnitude="Angle/T"    units="rad/s" help="X Angular Velocity"/></parameter>
-          <parameter n="iBy"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Angular Velocity Y" type="bool"   help="Set Initial Ang Velocity Y">
-           <parameter n="iAVy"                  parent="true"          v="0.0"   pn="   Value"         unit_magnitude="Angle/T"    units="rad/s" help="Y Angular Velocity"/></parameter>
-          <parameter n="iBz"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Angular Velocity Z" type="bool"   help="Set Initial Ang Velocity Z">
-           <parameter n="iAVz"                  parent="true"          v="0.0"   pn="   Value"         unit_magnitude="Angle/T"    units="rad/s" help="Z Angular Velocity"/></parameter>
+        <parameter n="DEM-InitialVelocities"  parent="FreeMotion"      v="No"    pn="Initial Velocities"             type="combo"  values="No,Yes" show_in_window="0">
+          <parameter n="iAx"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Velocity X"         type="bool"   help="Set Initial Velocity X" show_in_window="0">
+           <parameter n="iVx"                   parent="true"          v="0.0"   pn="   Value"           unit_magnitude="Velocity" units="m/s" help="X Velocity" show_in_window="0"/></parameter>
+          <parameter n="iAy"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Velocity Y"         type="bool"   help="Set Initial Velocity Y" show_in_window="0">
+           <parameter n="iVy"                   parent="true"          v="0.0"   pn="   Value"           unit_magnitude="Velocity" units="m/s" help="Y Velocity" show_in_window="0"/></parameter>
+          <parameter n="iAz"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Velocity Z"         type="bool"   help="Set Initial Velocity Z" show_in_window="0">
+           <parameter n="iVz"                   parent="true"          v="0.0"   pn="   Value"           unit_magnitude="Velocity" units="m/s" help="Z Velocity" show_in_window="0"/></parameter>
+          <parameter n="iBx"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Angular Velocity X" type="bool"   help="Set Initial Ang Velocity X" show_in_window="0">
+           <parameter n="iAVx"                  parent="true"          v="0.0"   pn="   Value"         unit_magnitude="Angle/T"    units="rad/s" help="X Angular Velocity" show_in_window="0"/></parameter>
+          <parameter n="iBy"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Angular Velocity Y" type="bool"   help="Set Initial Ang Velocity Y" show_in_window="0">
+           <parameter n="iAVy"                  parent="true"          v="0.0"   pn="   Value"         unit_magnitude="Angle/T"    units="rad/s" help="Y Angular Velocity" show_in_window="0"/></parameter>
+          <parameter n="iBz"                   parent="FreeMotion,Yes" v="false" pn="Set Initial Angular Velocity Z" type="bool"   help="Set Initial Ang Velocity Z" show_in_window="0">
+           <parameter n="iAVz"                  parent="true"          v="0.0"   pn="   Value"         unit_magnitude="Angle/T"    units="rad/s" help="Z Angular Velocity" show_in_window="0"/></parameter>
         </parameter>
 
-        <parameter n="DEM-RBImposedForces"  parent="FreeMotion"      type="combo"  v="No"          pn="Impose external forces" values="No,Yes">
-          <parameter n="ExternalForceX"      parent="FreeMotion,Yes" type="combo"  v="No"          pn="External Forces"  values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external force in the X direction to the group">
-          <parameter n="FX"                  parent="Constant"                     v="0.0"         pn="   Fx"            units="N" unit_magnitude="F" help="Insert the value of the external force in X direction"/>
-          <parameter n="FilenameFX"          parent="FromATable"     type="file"   v="- No file -" pn="   Filename"      help="Insert here the name of the file containing the external force in X direction"/></parameter>
-          <parameter n="ExternalForceY"      parent="FreeMotion,Yes" type="combo"  v="No"          pn="External Forces"  values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external force in the Y direction  to the group">
-          <parameter n="FY"                  parent="Constant"                     v="0.0"         pn="   Fy"            units="N" unit_magnitude="F" help="Insert the value of the external force in Y direction"/>
-          <parameter n="FilenameFY"          parent="FromATable"     type="file"   v="- No file -" pn="   Filename"      help="Insert here the name of the file containing the external force in Y direction"/></parameter>
-          <parameter n="ExternalForceZ"      parent="FreeMotion,Yes" type="combo"  v="No"          pn="External Forces"  values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external force in the Z direction  to the group">
-          <parameter n="FZ"                  parent="Constant"                     v="0.0"         pn="   Fz"            units="N" unit_magnitude="F" help="Insert the value of the external force in Z direction"/>
-          <parameter n="FilenameFZ"          parent="FromATable"     type="file"   v="- No file -" pn="   Filename"      help="Insert here the name of the file containing the external force in Z direction"/></parameter>
+        <parameter n="DEM-RBImposedForces"  parent="FreeMotion"      type="combo"  v="No"          pn="Impose external forces" values="No,Yes" show_in_window="0">
+          <parameter n="ExternalForceX"      parent="FreeMotion,Yes" type="combo"  v="No"          pn="External Forces"  values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external force in the X direction to the group" show_in_window="0">
+          <parameter n="FX"                  parent="Constant"                     v="0.0"         pn="   Fx"            units="N" unit_magnitude="F" help="Insert the value of the external force in X direction" show_in_window="0"/>
+          <parameter n="FilenameFX"          parent="FromATable"     type="file"   v="- No file -" pn="   Filename"      help="Insert here the name of the file containing the external force in X direction" show_in_window="0"/></parameter>
+          <parameter n="ExternalForceY"      parent="FreeMotion,Yes" type="combo"  v="No"          pn="External Forces"  values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external force in the Y direction  to the group" show_in_window="0">
+          <parameter n="FY"                  parent="Constant"                     v="0.0"         pn="   Fy"            units="N" unit_magnitude="F" help="Insert the value of the external force in Y direction" show_in_window="0"/>
+          <parameter n="FilenameFY"          parent="FromATable"     type="file"   v="- No file -" pn="   Filename"      help="Insert here the name of the file containing the external force in Y direction" show_in_window="0"/></parameter>
+          <parameter n="ExternalForceZ"      parent="FreeMotion,Yes" type="combo"  v="No"          pn="External Forces"  values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external force in the Z direction  to the group" show_in_window="0">
+          <parameter n="FZ"                  parent="Constant"                     v="0.0"         pn="   Fz"            units="N" unit_magnitude="F" help="Insert the value of the external force in Z direction" show_in_window="0"/>
+          <parameter n="FilenameFZ"          parent="FromATable"     type="file"   v="- No file -" pn="   Filename"      help="Insert here the name of the file containing the external force in Z direction" show_in_window="0"/></parameter>
         </parameter>
 
         <!-- <parameter n="DEM-RBImposedMoments"    parent="FreeMotion"                   pn="Impose external moments"> -->
-          <parameter n="ExternalMomentX"  parent="FreeMotion"   type="combo"  v="No"          pn="External Moments"   values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external moment in the X direction to the group">
-          <parameter n="MX"                parent="Constant"                  v="0.0"         pn="   Mx"              units="N*m" unit_magnitude="F*L" help="Insert the value of the external force in X direction"/>
-          <parameter n="FilenameMX"        parent="FromATable"  type="file"   v="- No file -" pn="   FilenameMx(N*m)" help="Insert here the name of the file containing the external force in X direction"/></parameter>
-          <parameter n="ExternalMomentY"   parent="FreeMotion"  type="combo"  v="No"          pn="External Moments"   values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external moment in the Y direction  to the group">
-          <parameter n="MY"                parent="Constant"                  v="0.0"         pn="   My"              units="N*m" unit_magnitude="F*L" help="Insert the value of the external force in Y direction"/>
-          <parameter n="FilenameMY"        parent="FromATable"  type="file"   v="- No file -" pn="   FilenameMy(N*m)" help="Insert here the name of the file containing the external force in Y direction"/></parameter>
-          <parameter n="ExternalMomentZ"   parent="FreeMotion"  type="combo"  v="No"          pn="External Moments"   values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external moment in the Z direction  to the group">
-          <parameter n="MZ"                parent="Constant"                  v="0.0"         pn="   Mz"              units="N*m" unit_magnitude="F*L" help="Insert the value of the external force in Z direction"/>
-          <parameter n="FilenameMZ"        parent="FromATable"  type="file"   v="- No file -" pn="   FilenameMz(N*m)" help="Insert here the name of the file containing the external force in Z direction"/></parameter>
+          <parameter n="ExternalMomentX"  parent="FreeMotion"   type="combo"  v="No"          pn="External Moments"   values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external moment in the X direction to the group" show_in_window="0">
+          <parameter n="MX"                parent="Constant"                  v="0.0"         pn="   Mx"              units="N*m" unit_magnitude="F*L" help="Insert the value of the external force in X direction" show_in_window="0"/>
+          <parameter n="FilenameMX"        parent="FromATable"  type="file"   v="- No file -" pn="   FilenameMx(N*m)" help="Insert here the name of the file containing the external force in X direction" show_in_window="0"/></parameter>
+          <parameter n="ExternalMomentY"   parent="FreeMotion"  type="combo"  v="No"          pn="External Moments"   values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external moment in the Y direction  to the group" show_in_window="0">
+          <parameter n="MY"                parent="Constant"                  v="0.0"         pn="   My"              units="N*m" unit_magnitude="F*L" help="Insert the value of the external force in Y direction" show_in_window="0"/>
+          <parameter n="FilenameMY"        parent="FromATable"  type="file"   v="- No file -" pn="   FilenameMy(N*m)" help="Insert here the name of the file containing the external force in Y direction" show_in_window="0"/></parameter>
+          <parameter n="ExternalMomentZ"   parent="FreeMotion"  type="combo"  v="No"          pn="External Moments"   values="No,Constant,FromATable" pvalues="No,Constant,From a table" help="Choose the way of imposing the external moment in the Z direction  to the group" show_in_window="0">
+          <parameter n="MZ"                parent="Constant"                  v="0.0"         pn="   Mz"              units="N*m" unit_magnitude="F*L" help="Insert the value of the external force in Z direction" show_in_window="0"/>
+          <parameter n="FilenameMZ"        parent="FromATable"  type="file"   v="- No file -" pn="   FilenameMz(N*m)" help="Insert here the name of the file containing the external force in Z direction" show_in_window="0"/></parameter>
         <!-- </parameter> -->
 
         <!-- <parameter n="Options"          parent="true" pn="Settings"                                      help="Options that will affect the behaviour during the contact bewteen Discrete Elements and this wall"> -->
-          <parameter n="IsGhost"         parent="true"  pn="Is ghost wall"      v="false" type="bool"/>
-          <parameter n="friction_coeff"  parent="true"  pn="Friction angle"     v="30.0"  type="double" units="deg" unit_magnitude="Angle" help="Coulomb friction coefficient"/>
-          <parameter n="GraphPrint"      parent="true"  pn="Print group forces" v="false" type="bool"/>
-          <parameter n="CohesiveWall"    parent="true"  pn="Cohesive Wall"      v="false" type="bool"   help="Specify if the wall presents a cohesive behaviour">
-           <parameter n="WallCohesion"   parent="true"  pn="Wall Cohesion"      v="0.0"   type="double" units="N/m^2" unit_magnitude="F/L^2" help="JKR or DMT energy surface"/> </parameter>
-          <parameter n="DEM_Wear"        parent="true"  pn="Compute Wear"       v="false" type="bool"   help="If activated, wear will be computed on this wall. It can increase computation time">
-           <parameter n="K_Abrasion"     parent="true"  pn="Abrasion level"     v="0.001" type="double" help="Archard abrasion K parameter"/>
-           <parameter n="K_Impact"       parent="true"  pn="Impact level"       v="0.001" type="double" help="Archard impact K parameter"/>
-           <parameter n="H_Brinell"      parent="true"  pn="Brinell Hardness"   v="200.0" type="double" help="Brinell hardness value"/> </parameter>
-          <parameter n="RigidPlane"      parent="true"  pn="Rigid Structure"    v="true" type="bool"   help="Give this DEM-FEM group an ideally rigid behaviour or an elastic response with a particular Young Modulus">
-           <parameter n="YoungModulus"   parent="false" pn="Young Modulus"      v="1e20"  type="double" units="N/m^2" unit_magnitude="F/L^2"/>
-           <parameter n="PoissonRatio"   parent="false" pn="Poisson Ratio"      v="0.25"/> </parameter>
-           <parameter n="fixed_wall"     parent="LinearPeriodic"  pn="Update velocity, not displacements"  v="false" type="bool" help="If activated, the wall will not move and will just have an imposed velocity field"/>
+          <parameter n="IsGhost"         parent="true"  pn="Is ghost wall"      v="false" type="bool" show_in_window="0"/>
+          <parameter n="friction_coeff"  parent="true"  pn="Friction angle"     v="30.0"  type="double" units="deg" unit_magnitude="Angle" help="Coulomb friction coefficient" show_in_window="0"/>
+          <parameter n="GraphPrint"      parent="true"  pn="Print group forces" v="false" type="bool" show_in_window="0"/>
+          <parameter n="CohesiveWall"    parent="true"  pn="Cohesive Wall"      v="false" type="bool"   help="Specify if the wall presents a cohesive behaviour" show_in_window="0">
+           <parameter n="WallCohesion"   parent="true"  pn="Wall Cohesion"      v="0.0"   type="double" units="N/m^2" unit_magnitude="F/L^2" help="JKR or DMT energy surface" show_in_window="0"/> </parameter>
+          <parameter n="DEM_Wear"        parent="true"  pn="Compute Wear"       v="false" type="bool"   help="If activated, wear will be computed on this wall. It can increase computation time" show_in_window="0">
+           <parameter n="K_Abrasion"     parent="true"  pn="Abrasion level"     v="0.001" type="double" help="Archard abrasion K parameter" show_in_window="0"/>
+           <parameter n="K_Impact"       parent="true"  pn="Impact level"       v="0.001" type="double" help="Archard impact K parameter" show_in_window="0"/>
+           <parameter n="H_Brinell"      parent="true"  pn="Brinell Hardness"   v="200.0" type="double" help="Brinell hardness value" show_in_window="0"/> </parameter>
+          <parameter n="RigidPlane"      parent="true"  pn="Rigid Structure"    v="true" type="bool"   help="Give this DEM-FEM group an ideally rigid behaviour or an elastic response with a particular Young Modulus" show_in_window="0">
+           <parameter n="YoungModulus"   parent="false" pn="Young Modulus"      v="1e20"  type="double" units="N/m^2" unit_magnitude="F/L^2" show_in_window="0"/>
+           <parameter n="PoissonRatio"   parent="false" pn="Poisson Ratio"      v="0.25" show_in_window="0"/> </parameter>
+           <parameter n="fixed_wall"     parent="LinearPeriodic"  pn="Update velocity, not displacements"  v="false" type="bool" help="If activated, the wall will not move and will just have an imposed velocity field" show_in_window="0"/>
           <!-- <parameter n="is-embedded-in-fluid"                    pn="Embed this Wall in the fluid"        v="false" type="bool" state="hidden" help="If activated, the fluid will also feel this group as a wall"/> -->
         <!-- </parameter> -->
 
         <!-- <parameter n="LinearVelocity"    parent="LinearPeriodic" pn="Linear velocity"> -->
-          <parameter n="VelocityModulus" parent="LinearPeriodic" pn="Velocity" type="double"        v="1.0"    units="m/s" unit_magnitude="Velocity"/>
-          <parameter n="DirectionVector" parent="LinearPeriodic" pn="Direction vector" type="inline_vector" v="1.0,0.0,0.0" />
-          <parameter n="LinearPeriodic"  parent="LinearPeriodic" pn="Periodic"         type="bool"          v="false"  help="If activated, the imposed velocity values are the maximum during a harmonic oscillation with a given period">
-           <parameter n="LinearPeriod"    parent="true"          pn="Period"           type="double"        v="5.0"    units="s" unit_magnitude="T"/> </parameter>
-          <parameter n="LinearStartTime" parent="LinearPeriodic" pn="Start time"       type="double"        v="0.0"    units="s" unit_magnitude="T"/>
-          <parameter n="LinearEndTime"   parent="LinearPeriodic" pn="End time"         type="double"        v="100.0"  units="s" unit_magnitude="T"/>
+          <parameter n="VelocityModulus" parent="LinearPeriodic" pn="Velocity" type="double"        v="1.0"    units="m/s" unit_magnitude="Velocity" show_in_window="0"/>
+          <parameter n="DirectionVector" parent="LinearPeriodic" pn="Direction vector" type="inline_vector" v="1.0,0.0,0.0"  show_in_window="0"/>
+          <parameter n="LinearPeriodic"  parent="LinearPeriodic" pn="Periodic"         type="bool"          v="false"  help="If activated, the imposed velocity values are the maximum during a harmonic oscillation with a given period" show_in_window="0">
+           <parameter n="LinearPeriod"    parent="true"          pn="Period"           type="double"        v="5.0"    units="s" unit_magnitude="T" show_in_window="0"/> </parameter>
+          <parameter n="LinearStartTime" parent="LinearPeriodic" pn="Start time"       type="double"        v="0.0"    units="s" unit_magnitude="T" show_in_window="0"/>
+          <parameter n="LinearEndTime"   parent="LinearPeriodic" pn="End time"         type="double"        v="100.0"  units="s" unit_magnitude="T" show_in_window="0"/>
         <!-- </parameter> -->
 
         <!-- <parameter n="AngularVelocity"    parent="LinearPeriodic" pn="Angular velocity"> -->
-          <parameter n="AngularVelocityModulus" parent="LinearPeriodic" pn="Angular velocity"   type="double"        v="0.0"    units="rad/s" unit_magnitude="Angle/T"/>
-          <parameter n="AngularDirectionVector" parent="LinearPeriodic" pn="Direction vector"   type="inline_vector" v="1.0,0.0,0.0" />
-          <parameter n="CenterOfRotation"       parent="LinearPeriodic" pn="Center of rotation" type="inline_vector" v="0.0,0.0,0.0" units="m" unit_magnitude="L" help="Components of the position of the Rotation Center. If a linear velocity is imposed to this group, it will affect this center"/>
-          <parameter n="AngularPeriodic"        parent="LinearPeriodic" pn="Periodic"           type="bool"          v="false"  help="If activated, the imposed velocity values are the maximum during a harmonic oscillation with a given period">
-           <parameter n="AngularPeriod"          parent="true"          pn="Period"             type="double"        v="5.0"    units="s"      unit_magnitude="T"/> </parameter>
-          <parameter n="AngularStartTime"       parent="LinearPeriodic" pn="Start time"         type="double"        v="0.0"    units="s"      unit_magnitude="T"/>
-          <parameter n="AngularEndTime"         parent="LinearPeriodic" pn="End time"           type="double"        v="100.0"  units="s"      unit_magnitude="T"/>
+          <parameter n="AngularVelocityModulus" parent="LinearPeriodic" pn="Angular velocity"   type="double"        v="0.0"    units="rad/s" unit_magnitude="Angle/T" show_in_window="0"/>
+          <parameter n="AngularDirectionVector" parent="LinearPeriodic" pn="Direction vector"   type="inline_vector" v="1.0,0.0,0.0"  show_in_window="0"/>
+          <parameter n="CenterOfRotation"       parent="LinearPeriodic" pn="Center of rotation" type="inline_vector" v="0.0,0.0,0.0" units="m" unit_magnitude="L" help="Components of the position of the Rotation Center. If a linear velocity is imposed to this group, it will affect this center" show_in_window="0"/>
+          <parameter n="AngularPeriodic"        parent="LinearPeriodic" pn="Periodic"           type="bool"          v="false"  help="If activated, the imposed velocity values are the maximum during a harmonic oscillation with a given period" show_in_window="0">
+           <parameter n="AngularPeriod"          parent="true"          pn="Period"             type="double"        v="5.0"    units="s"      unit_magnitude="T" show_in_window="0"/> </parameter>
+          <parameter n="AngularStartTime"       parent="LinearPeriodic" pn="Start time"         type="double"        v="0.0"    units="s"      unit_magnitude="T" show_in_window="0"/>
+          <parameter n="AngularEndTime"         parent="LinearPeriodic" pn="End time"           type="double"        v="100.0"  units="s"      unit_magnitude="T" show_in_window="0"/>
         <!-- </parameter> -->
       </parameter>
     </parameter>

--- a/kratos.gid/scripts/Controllers/TreeInjections.tcl
+++ b/kratos.gid/scripts/Controllers/TreeInjections.tcl
@@ -248,6 +248,10 @@ proc spdAux::GetParameterValueString { param {forcedParams ""} {base ""}} {
     set um ""
     set n ""
     set special_command [$param getAttribute "special_command"]
+    set show_in_window 1
+    if {[$param hasAttribute "show_in_window"]} {
+        set show_in_window [$param getAttribute "show_in_window"]
+    }
 
     if {$special_command ne ""} {
         set params [$param getAttribute "args"]
@@ -280,7 +284,7 @@ proc spdAux::GetParameterValueString { param {forcedParams ""} {base ""}} {
                 set ndim [string index $::Model::SpatialDimension 0]
                 # TODO: Add units when Compassis enables units in vectors
                 #append node "<value n='$inName' pn='$pn' v='$v' fieldtype='vector' $has_units  dimensions='$ndim'  help='$help'  state='$state' />"
-                append node "<value n='$inName' pn='$pn' v='$v' fieldtype='vector' dimensions='$ndim'  help='$help'  state='$state' />"
+                append node "<value n='$inName' pn='$pn' v='$v' fieldtype='vector' dimensions='$ndim'  help='$help'  state='$state' show_in_window='$show_in_window' />"
             }
             "vector" {
                 set vector_type [$param getAttribute "vectorType"]
@@ -289,9 +293,9 @@ proc spdAux::GetParameterValueString { param {forcedParams ""} {base ""}} {
                     set zstate "\[CheckDimension 3D\]"
                     if {$state eq "hidden"} {set zstate hidden}
                     append node "
-                        <value n='${inName}X' wn='[concat $n "_X"]' pn='X ${pn}' v='$vX' values='1,0' help='' state='$state'/>
-                        <value n='${inName}Y' wn='[concat $n "_Y"]' pn='Y ${pn}' v='$vY' values='1,0' help='' state='$state'/>
-                        <value n='${inName}Z' wn='[concat $n "_Z"]' pn='Z ${pn}' v='$vZ' values='1,0' help='' state='$zstate'/>"
+                        <value n='${inName}X' wn='[concat $n "_X"]' pn='X ${pn}' v='$vX' values='1,0' help='' state='$state' show_in_window='$show_in_window'/>
+                        <value n='${inName}Y' wn='[concat $n "_Y"]' pn='Y ${pn}' v='$vY' values='1,0' help='' state='$state' show_in_window='$show_in_window'/>
+                        <value n='${inName}Z' wn='[concat $n "_Z"]' pn='Z ${pn}' v='$vZ' values='1,0' help='' state='$zstate' show_in_window='$show_in_window'/>"
                 } else {
                     foreach i [list "X" "Y" "Z"] {
                         set fname "function_$inName"
@@ -302,7 +306,7 @@ proc spdAux::GetParameterValueString { param {forcedParams ""} {base ""}} {
                         if {[$param getAttribute "enabled"] in [list "1" "0"]} {
                             set val [expr [$param getAttribute "enabled"] ? "Yes" : "No"]
                             #if {$i eq "Z"} { set val "No" }
-                            append node "<value n='Enabled_$i' pn='$i component' v='$val' values='Yes,No'  help='Enables the $i ${inName}' $zstate >"
+                            append node "<value n='Enabled_$i' pn='$i component' v='$val' values='Yes,No'  help='Enables the $i ${inName}' $zstate  show_in_window='$show_in_window'>"
                             append node "<dependencies value='No' node=\""
                             append node $nodev
                             append node "\" att1='state' v1='hidden'/>"
@@ -327,7 +331,7 @@ proc spdAux::GetParameterValueString { param {forcedParams ""} {base ""}} {
                         }
                         if {[$param getAttribute "function"] eq "1"} {
                             set fname "${i}function_$inName"
-                            append node "<value n='ByFunction$i' pn='by function -> f(x,y,z,t)' v='No' values='Yes,No'  actualize_tree='1'  $zstate >
+                            append node "<value n='ByFunction$i' pn='by function -> f(x,y,z,t)' v='No' values='Yes,No'  actualize_tree='1'  $zstate  show_in_window='$show_in_window'>
                                 <dependencies value='No' node=\""
                             append node $nodev
                             append node "\" att1='state' v1='normal'/>
@@ -346,9 +350,9 @@ proc spdAux::GetParameterValueString { param {forcedParams ""} {base ""}} {
                         set v "v$i"
                         if { $vector_type eq "file" || $vector_type eq "tablefile" } {
                             if {[set $v] eq ""} {set $v "- No file"}
-                            append node "<value n='${inName}$i' wn='[concat $n "_$i"]' pn='$i ${pn}' v='[set $v]' values='\[GetFilesValues\]' update_proc='AddFile' help='$help'  $zstate  type='$vector_type'/>"
+                            append node "<value n='${inName}$i' wn='[concat $n "_$i"]' pn='$i ${pn}' v='[set $v]' values='\[GetFilesValues\]' update_proc='AddFile' help='$help'  $zstate  type='$vector_type' show_in_window='$show_in_window'/>"
                         } else {
-                            append node "<value n='${inName}$i' wn='[concat $n "_$i"]' pn='$i ${pn}' v='[set $v]' $has_units help='$help'  $zstate />"
+                            append node "<value n='${inName}$i' wn='[concat $n "_$i"]' pn='$i ${pn}' v='[set $v]' $has_units help='$help'  $zstate  show_in_window='$show_in_window'/>"
                         }
                     }
                 }
@@ -371,7 +375,7 @@ proc spdAux::GetParameterValueString { param {forcedParams ""} {base ""}} {
                 if {[$param getActualize]} {
                     append node "  actualize_tree='1'  "
                 }
-                append node " state='$state' help='$help'>"
+                append node " state='$state' help='$help' show_in_window='$show_in_window'>"
                 if {$base ne ""} { append node [_insert_cond_param_dependencies $base $inName] }
                 append node "</value>"
             }
@@ -383,23 +387,23 @@ proc spdAux::GetParameterValueString { param {forcedParams ""} {base ""}} {
                 if {[$param getActualize]} {
                     append node "  actualize_tree='1'  "
                 }
-                append node " state='$state'>"
+                append node " state='$state'  show_in_window='$show_in_window'>"
                 if {$base ne ""} {append node [_insert_cond_param_dependencies $base $inName]}
                 append node "</value>"
             }
             "file" -
             "tablefile" {
-                append node "<value n='$inName' pn='$pn' v='$v' values='\[GetFilesValues\]' update_proc='AddFile' help='$help' state='$state' type='$type'/>"
+                append node "<value n='$inName' pn='$pn' v='$v' values='\[GetFilesValues\]' update_proc='AddFile' help='$help' state='$state' type='$type'  show_in_window='$show_in_window'/>"
             }
             "integer" {
-                append node "<value n='$inName' pn='$pn' v='$v' $has_units  help='$help' string_is='integer'/>"
+                append node "<value n='$inName' pn='$pn' v='$v' $has_units  help='$help' string_is='integer'  show_in_window='$show_in_window'/>"
             }
             default {
                 if {[$param getAttribute "function"] eq "1"} {
                     set fname "function_$inName"
                     set nodev "../value\[@n='$inName'\]"
                     set nodef "../value\[@n='$fname'\]"
-                    append node "<value n='ByFunction' pn='by function -> f(x,y,z,t)' v='No' values='Yes,No'  actualize_tree='1' state='$state'>
+                    append node "<value n='ByFunction' pn='by function -> f(x,y,z,t)' v='No' values='Yes,No'  actualize_tree='1' state='$state'  show_in_window='$show_in_window'>
                         <dependencies value='No' node=\""
                     append node $nodev
                     append node "\" att1='state' v1='normal'/>
@@ -414,9 +418,9 @@ proc spdAux::GetParameterValueString { param {forcedParams ""} {base ""}} {
                     append node "\" att1='state' v1='normal'/>
                         </value>"
 
-                    append node "<value n='$fname' pn='Function' v='' help='$help'  state='$state'/>"
+                    append node "<value n='$fname' pn='Function' v='' help='$help'  state='$state'  show_in_window='$show_in_window'/>"
                 }
-                append node "<value n='$inName' pn='$pn' v='$v' $has_units  help='$help' string_is='double'  state='$state'/>"
+                append node "<value n='$inName' pn='$pn' v='$v' $has_units  help='$help' string_is='double'  state='$state'  show_in_window='$show_in_window'/>"
             }
         }
     }


### PR DESCRIPTION
Hi @KratosMultiphysics/dem people,

GiD is deploying it's 14.1.4d version soon. In this version, we include a new parameter to hide entries in the conditions window, but show it the tree.
So, with this PR, the condition DEM-FEM Wall will change from this:
![image](https://user-images.githubusercontent.com/5918085/61654236-456b4d80-acbc-11e9-953a-b4dad84c1030.png)

to this:
![image](https://user-images.githubusercontent.com/5918085/61654290-659b0c80-acbc-11e9-9e15-2804cf601ee9.png)
But in the tree:
![image](https://user-images.githubusercontent.com/5918085/61654347-82cfdb00-acbc-11e9-965c-7a24af709479.png)


So you can check this development and implement it in the rest of laaaarge processes DEM uses.
