### PR TITLE
Add raileigh parameters to implicit

### DIFF
--- a/kratos.gid/apps/Structural/xml/Strategies.xml
+++ b/kratos.gid/apps/Structural/xml/Strategies.xml
@@ -3,6 +3,8 @@
     <StrategyItem n="implicit" pn="Implicit" SolutionType="Dynamic" ImplementedInFile="structural_mechanics_implicit_dynamic_solver.py" ImplementedInApplication="StructuralMechanicsApplication" ImplementedInPythonFile="structural_mechanics_implicit_dynamic_solver" MinimumKratosVersion="8500" App="Structural" ProductionReady="ProductionReady" help="">
         <parameter_list>
             <parameter n="echo_level" pn="Echo level" type="combo" v="0" values="0,1,2,3" help=""/>
+            <parameter n="raileigh_alpha" pn="Raileigh alpha" type="double" v="0.0"  help=""/>
+            <parameter n="raileigh_beta" pn="Raileigh beta" type="double" v="0.0"  help=""/>
             <parameter n="line_search" pn="Line search" type="bool" v="false" values="false,true" help="Switch on/off line search"/>
             <parameter n="convergence_criterion" pn="Convergence criterion" type="combo" v="residual_criterion" values ="residual_criterion,displacement_criterion,And_criterion,or_criterion"
                        pvalues ="Residual criterion,Displacement criterion,And criterion,Or criterion" help="These are the available convergence criteria for the nonlinear iteration">


### PR DESCRIPTION
implements #632 

It appears in the tree in the strategy parameters:
![image](https://user-images.githubusercontent.com/5918085/63435296-f897a580-c426-11e9-9af3-53800d49f812.png)
And in the json:
```
    "solver_settings"  : {
        "solver_type"                     : "Dynamic",
        "model_part_name"                 : "Structure",
        "domain_size"                     : 2,
        "echo_level"                      : 0,
        "analysis_type"                   : "non_linear",
        "time_integration_method"         : "implicit",
        "scheme_type"                     : "newmark",
        "model_import_settings"           : {
            "input_type"     : "mdpa",
            "input_filename" : "raileig_example"
        },
        "material_import_settings"        : {
            "materials_filename" : "StructuralMaterials.json"
        },
        "time_stepping"                   : {
            "time_step" : 0.05
        },
        "raileigh_alpha"                  : 0.01,
        "raileigh_beta"                   : 0.02,
        "line_search"                     : false,
        "convergence_criterion"           : "residual_criterion",
        "displacement_relative_tolerance" : 0.0001,
        "displacement_absolute_tolerance" : 1e-9,
        "residual_relative_tolerance"     : 0.0001,
        "residual_absolute_tolerance"     : 1e-9,
        "max_iteration"                   : 10,
        "rotation_dofs"                   : false
    }
```