### PR TITLE
Meshcriteria is resetted on all surfaces of the model

### DIFF
--- a/kratos.gid/apps/DEM/write/write_utils.tcl
+++ b/kratos.gid/apps/DEM/write/write_utils.tcl
@@ -373,8 +373,6 @@ proc DEM::write::BeforeMeshGenerationUtils {elementsize} {
     set groupid "-AKGSkinMesh3D"
     DEM::write::CleanAutomaticConditionGroupGiD $entitytype $groupid
 
-    GiD_Process Mescape Meshing MeshCriteria NoMesh Surfaces : escape
-
     # Find boundaries
     if {[GiD_Groups exists SKIN_SPHERE_DO_NOT_DELETE]} {
 	    GiD_Groups delete SKIN_SPHERE_DO_NOT_DELETE

--- a/kratos.gid/apps/DEM/write/write_utils.tcl
+++ b/kratos.gid/apps/DEM/write/write_utils.tcl
@@ -373,6 +373,8 @@ proc DEM::write::BeforeMeshGenerationUtils {elementsize} {
     set groupid "-AKGSkinMesh3D"
     DEM::write::CleanAutomaticConditionGroupGiD $entitytype $groupid
 
+    GiD_Process Mescape Meshing MeshCriteria NoMesh Surfaces : escape
+
     # Find boundaries
     if {[GiD_Groups exists SKIN_SPHERE_DO_NOT_DELETE]} {
 	    GiD_Groups delete SKIN_SPHERE_DO_NOT_DELETE

--- a/kratos.gid/kratos.tcl
+++ b/kratos.gid/kratos.tcl
@@ -353,10 +353,16 @@ proc Kratos::TransformProblemtype {old_dom old_filespd} {
 proc Kratos::Event_BeforeMeshGeneration {elementsize} {
     # Prepare things before meshing
 
+    
+    GiD_Process Mescape Meshing MeshCriteria NoMesh Lines 1:end escape escape escape
+    GiD_Process Mescape Meshing MeshCriteria NoMesh Surfaces 1:end escape escape escape
+    GiD_Process Mescape Meshing MeshCriteria NoMesh Volumes 1:end escape escape escape
+
     # We need to mesh every line and surface assigned to a group that appears in the tree 
     foreach group [spdAux::GetAppliedGroups] {
         GiD_Process Mescape Meshing MeshCriteria Mesh Lines {*}[GiD_EntitiesGroups get $group lines] escape escape escape
-        GiD_Process Mescape Meshing MeshCriteria Mesh Surfaces {*}[GiD_EntitiesGroups get $group surfaces] escape escape
+        GiD_Process Mescape Meshing MeshCriteria Mesh Surfaces {*}[GiD_EntitiesGroups get $group surfaces] escape escape escape
+        GiD_Process Mescape Meshing MeshCriteria Mesh Volumes {*}[GiD_EntitiesGroups get $group volumes] escape escape escape
     }
     # Maybe the current application needs to do some extra job
     set ret [apps::ExecuteOnCurrentApp BeforeMeshGeneration $elementsize]


### PR DESCRIPTION
The problem was the following:
1- Group created and assigned to condition DEM-FEM-Wall
2- Mesh (MeshCriteria Mesh is applied to the surfaces in the group)
3- You unassign some surfaces from that group
4- Mesh -> BUG: some surfaces are being meshed that should not be. Nobody was resetting the MeshCriteria Mesh.
I don't see how I can fix this bug in a different way. I know that this may interfere with other applications coupled with DEM.