### PR TITLE
[All] Linear solvers clean up

### DIFF
--- a/kratos.gid/apps/Common/xml/Solvers.xml
+++ b/kratos.gid/apps/Common/xml/Solvers.xml
@@ -7,22 +7,12 @@
         </inputs>
     </solver>
 
-    <solver n="ExternalSolversApplication.super_lu" pn="SuperLU" SolverType="Standard" Parallelism="OpenMP">
+    <solver n="EigenSolversApplication.sparse_lu" pn="SparseLU" SolverType="Standard" Parallelism="OpenMP">
         <inputs>
-            <parameter n="scaling" pn="Scaling" type="bool" v="False"  help=""/>
         </inputs>
     </solver>
 
     <solver n="cg" pn="Conjugate Gradients" SolverType="Standard" Parallelism="OpenMP">
-        <inputs>
-            <parameter n="max_iteration" pn="Max iterations" type="integer" v="200" help=""/>
-            <parameter n="tolerance" pn="Tolerance" type="integer"  v="1e-7" help=""/>
-			<parameter n="preconditioner_type" pn="Preconditioner" type="combo" values="None,DiagonalPreconditioner,ILU0Preconditioner" v="None" help=""/>
-			<parameter n="scaling" pn="Scaling" type="bool" v="False" help=""/>
-        </inputs>
-    </solver>
-
-    <solver n="ExternalSolversApplication.gmres" pn="GMRES" SolverType="Standard" Parallelism="OpenMP">
         <inputs>
             <parameter n="max_iteration" pn="Max iterations" type="integer" v="200" help=""/>
             <parameter n="tolerance" pn="Tolerance" type="integer"  v="1e-7" help=""/>

--- a/kratos.gid/apps/Dam/xml/Solvers.xml
+++ b/kratos.gid/apps/Dam/xml/Solvers.xml
@@ -6,9 +6,8 @@
         </inputs>
     </solver>
 
-    <solver n="super_lu" pn="SuperLU" SolverType="Standard" Parallelism="OpenMP">
+    <solver n="EigenSolversApplication.sparse_lu" pn="SparseLU" SolverType="Standard" Parallelism="OpenMP">
         <inputs>
-            <parameter n="scaling" pn="Scaling" type="bool" v="False"  help=""/>
         </inputs>
     </solver>
 

--- a/kratos.gid/apps/MPM/xml/XmlController.tcl
+++ b/kratos.gid/apps/MPM/xml/XmlController.tcl
@@ -61,7 +61,7 @@ proc MPM::xml::CustomTree { args } {
     spdAux::SetValueOnTreeItem v "time" Results OutputControlType
     spdAux::SetValueOnTreeItem values "time" Results OutputControlType
     spdAux::SetValueOnTreeItem v No NodalResults PARTITION_INDEX
-    spdAux::SetValueOnTreeItem v "ExternalSolversApplication.super_lu" MPMimplicitlinear_solver_settings Solver
+    spdAux::SetValueOnTreeItem v "EigenSolversApplication.sparse_lu" MPMimplicitlinear_solver_settings Solver
 }
 
 

--- a/kratos.gid/apps/Pfem/write/ProjectParameters.json
+++ b/kratos.gid/apps/Pfem/write/ProjectParameters.json
@@ -17,7 +17,7 @@
         "time_integration_method"            : "Implicit",
         "scheme_type"                        : "Newmark",
         "model_import_settings"              : {
-            "input_type"       : "mdpa",  
+            "input_type"       : "mdpa",
             "input_filename"   : "Particle Domain",
             "input_file_label" : "0"
         },
@@ -30,10 +30,7 @@
         "residual_absolute_tolerance"        : 1e-9,
         "max_iteration"                      : 25,
         "linear_solver_settings"             : {
-             "solver_type" : "super_lu",
-             "tolerance"   : 1e-7,
-             "max_iteration" : 5000,
-             "scaling"     : false
+             "solver_type" : "ExternalSolversApplication.sparse_lu"
         },
         "bodies_list": [
             {"body_name":"body1",
@@ -111,14 +108,14 @@
 			    "on_distance": false,
 			    "on_threshold": false,
 			    "on_error": false
-			},              
+			},
 			"refining_box":{
 			    "refine_in_box_only": false,
 			    "upper_point": [0.0, 0.0, 0.0],
 			    "lower_point": [0.0, 0.0, 0.0],
 			    "velocity": [0.0, 0.0, 0.0]
 			}
-		    },            
+		    },
 		    "elemental_variables_to_transfer":[ "CAUCHY_STRESS_VECTOR", "DEFORMATION_GRADIENT" ]
 		}
 	    ]
@@ -174,7 +171,7 @@
                         }
                     }
                 }
-    
+
             ]
         }
     },{
@@ -321,9 +318,9 @@
             "nodal_results"       : ["DISPLACEMENT","REACTION","VELOCITY","ACCELERATION"],
             "gauss_point_results" : ["GREEN_LAGRANGE_STRAIN_TENSOR","CAUCHY_STRESS_TENSOR","VON_MISES_STRESS"],
 	    "additional_list_files": []
-			    
+
         },
         "point_data_configuration"  : []
     }
-    
+
 }

--- a/kratos.gid/apps/Pfem/xml/Solvers.xml
+++ b/kratos.gid/apps/Pfem/xml/Solvers.xml
@@ -4,15 +4,12 @@
         <inputs>
         </inputs>
     </solver>
-    
-    <solver n="ExternalSolversApplication.super_lu" pn="SuperLU" SolverType="Standard">
+
+    <solver n="EigenSolversApplication.sparse_lu" pn="SparseLU" SolverType="Standard" Parallelism="OpenMP">
         <inputs>
-            <parameter n="scaling" pn="Scaling" type="bool" v="False"  help=""/>
-<!--
-            <parameter n="verbosity" pn="Verbosity" type="combo" values="0,1,2,3" v="0" help=""/>
--->
         </inputs>
     </solver>
+
     <solver n="cg" pn="Conjugate Gradients" SolverType="Standard">
         <inputs>
             <parameter n="max_iteration" pn="Max iterations" type="integer" v="5000" help=""/>
@@ -24,17 +21,7 @@
 -->
         </inputs>
     </solver>
-    <solver n="ExternalSolversApplication.gmres" pn="GMRES" SolverType="Standard">
-        <inputs>
-            <parameter n="max_iteration" pn="Max iterations" type="integer" v="5000" help=""/>
-            <parameter n="tolerance" pn="Tolerance" type="integer"  v="1e-9" help=""/>
-			<parameter n="preconditioner_type" pn="Preconditioner" type="combo" values="none,diagonal,ilu0" v="None" help=""/>
-			<parameter n="scaling" pn="Scaling" type="bool" v="False" help=""/>
-<!--
-            <parameter n="verbosity" pn="Verbosity" type="combo" values="0,1,2,3" v="0" help=""/>
--->
-        </inputs>
-    </solver>
+
     <solver n="bicgstab" pn="BiCGStab" SolverType="Standard">
         <inputs>
             <parameter n="max_iteration" pn="Max iterations" type="integer" v="5000" help=""/>

--- a/kratos.gid/apps/PfemFluid/write/ProjectParameters.json
+++ b/kratos.gid/apps/PfemFluid/write/ProjectParameters.json
@@ -30,10 +30,7 @@
         "residual_absolute_tolerance"        : 1e-9,
         "max_iteration"                      : 25,
         "linear_solver_settings"             : {
-             "solver_type" : "super_lu",
-             "tolerance"   : 1e-7,
-             "max_iteration" : 5000,
-             "scaling"     : false
+             "solver_type" : "ExternalSolversApplication.sparse_lu"
         },
         "bodies_list": [
             {"body_name":"body1",

--- a/kratos.gid/apps/PfemFluid/xml/Solvers.xml
+++ b/kratos.gid/apps/PfemFluid/xml/Solvers.xml
@@ -4,15 +4,12 @@
         <inputs>
         </inputs>
     </solver>
-    
-    <solver n="ExternalSolversApplication.super_lu" pn="SuperLU" SolverType="Standard">
+
+    <solver n="EigenSolversApplication.sparse_lu" pn="SparseLU" SolverType="Standard" Parallelism="OpenMP">
         <inputs>
-            <parameter n="scaling" pn="Scaling" type="bool" v="False"  help=""/>
-<!--
-            <parameter n="verbosity" pn="Verbosity" type="combo" values="0,1,2,3" v="0" help=""/>
--->
         </inputs>
     </solver>
+
     <solver n="cg" pn="Conjugate Gradients" SolverType="Standard">
         <inputs>
             <parameter n="max_iteration" pn="Max iterations" type="integer" v="5000" help=""/>
@@ -24,17 +21,7 @@
 -->
         </inputs>
     </solver>
-    <solver n="ExternalSolversApplication.gmres" pn="GMRES" SolverType="Standard">
-        <inputs>
-            <parameter n="max_iteration" pn="Max iterations" type="integer" v="5000" help=""/>
-            <parameter n="tolerance" pn="Tolerance" type="integer"  v="1e-9" help=""/>
-			<parameter n="preconditioner_type" pn="Preconditioner" type="combo" values="none,diagonal,ilu0" v="ilu0" help=""/>
-			<parameter n="scaling" pn="Scaling" type="bool" v="False" help=""/>
-<!--
-            <parameter n="verbosity" pn="Verbosity" type="combo" values="0,1,2,3" v="0" help=""/>
--->
-        </inputs>
-    </solver>
+
     <solver n="bicgstab" pn="BiCGStab" SolverType="Standard">
         <inputs>
             <parameter n="max_iteration" pn="Max iterations" type="integer" v="5000" help=""/>


### PR DESCRIPTION
Required changes according to https://github.com/KratosMultiphysics/Kratos/pull/6741.

@jginternational note that the `ExternalSolversApplication` is being deprecated in favour of the `EigenSolversApplication`. We should start packaging the second one instead of the first one.

Another question I have is why the PFEM applications are not using the common `solvers.xml`. As far as I see they have exactly the same solvers.