### PR TITLE
[Fluid] Add monolithic time scheme selection

### DIFF
--- a/kratos.gid/apps/Fluid/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/Fluid/write/writeProjectParameters.tcl
@@ -191,6 +191,11 @@ proc Fluid::write::getSolverSettingsDict { } {
     # No skin parts
     dict set solverSettingsDict no_skin_parts [getNoSkinConditionMeshId]
 
+    # Time scheme settings
+    if {$currentStrategyId eq "Monolithic"} {
+        dict set solverSettingsDict time_scheme [write::getValue FLScheme]
+    }
+
     # Time stepping settings
     set timeSteppingDict [dict create]
     set automaticDeltaTime [write::getValue FLTimeParameters AutomaticDeltaTime]

--- a/kratos.gid/apps/Fluid/xml/AnalysisType.spd
+++ b/kratos.gid/apps/Fluid/xml/AnalysisType.spd
@@ -2,6 +2,7 @@
 <container n="AnalysisType" pn="Analysis Type" help="Analysis information" icon="analysis" state="normal" open_window="0">
     <value n="FreeSurface" pn="Free Surface" un="FLFreeSurface" v="No" values="Yes,No" help="Analysis type" state="hidden"/>
     <value n="SolStrat" pn="Solution Strategy" un="FLSolStrat" v="" values="" dict="[GetSolutionStrategies App Fluid]" actualize_tree="1"/>
-    <value n="Scheme" pn="Scheme" un="FLScheme" v="" values="" dict="[GetSchemes]" actualize_tree="1" state="[getStateFromXPathValue {string(../value[@n='SolStrat']/@v)} Monolithic]"/>
+    <value n="Scheme" pn="Scheme" un="FLScheme" v="" values="" dict="[GetSchemes]" actualize_tree="1" state="[checkStateByUniqueName FLSolStrat Monolithic]"/>
+
 </container>
     

--- a/kratos.gid/apps/Fluid/xml/AnalysisType.spd
+++ b/kratos.gid/apps/Fluid/xml/AnalysisType.spd
@@ -2,6 +2,6 @@
 <container n="AnalysisType" pn="Analysis Type" help="Analysis information" icon="analysis" state="normal" open_window="0">
     <value n="FreeSurface" pn="Free Surface" un="FLFreeSurface" v="No" values="Yes,No" help="Analysis type" state="hidden"/>
     <value n="SolStrat" pn="Solution Strategy" un="FLSolStrat" v="" values="" dict="[GetSolutionStrategies App Fluid]" actualize_tree="1"/>
-    <value n="Scheme" pn="Scheme" un="FLScheme" v="" values="" dict="[GetSchemes]" actualize_tree="1" state="disabled"/>
+    <value n="Scheme" pn="Scheme" un="FLScheme" v="" values="" dict="[GetSchemes]" actualize_tree="1" state="[getStateFromXPathValue {string(../value[@n='SolStrat']/@v)} Monolithic]"/>
 </container>
     

--- a/kratos.gid/apps/Fluid/xml/Strategies.xml
+++ b/kratos.gid/apps/Fluid/xml/Strategies.xml
@@ -40,13 +40,18 @@
 
 		<!-- scheme settings -->
 		<schemes>
-			<scheme n="MN" pn="Monolitic generic scheme" help="FilterElements" ProductionReady="ProductionReady">
-				<parameter_list>
-				</parameter_list>
-				<element_filters>
-					<filter field="n" value="Monolithic2D,Monolithic3D"/>
-				</element_filters>
-			</scheme>
+			<scheme n="bossak" pn="Bossak" help="Bossak scheme for CFD problems." ProductionReady="ProductionReady">
+                <parameter_list></parameter_list>
+                <element_filters>
+                    <filter field="n" value="Monolithic2D,Monolithic3D"/>
+                </element_filters>
+            </scheme>
+			<scheme n="bdf2" pn="BDF2" help="2nd order Backward Differenctiation Formula (BDF2) scheme for CFD problems." ProductionReady="ProductionReady">
+                <parameter_list></parameter_list>
+                <element_filters>
+                    <filter field="n" value="Monolithic2D,Monolithic3D"/>
+                </element_filters>
+            </scheme>
 		</schemes>
 	</StrategyItem>
 


### PR DESCRIPTION
After [#6879](https://github.com/KratosMultiphysics/Kratos/pull/6879) it would be possible to use the `BDF2` scheme with slip BCs. Hence, we can expose it in the CFD GUI when selecting monolithic strategies.