### PR TITLE
Hide end calculation window

### DIFF
--- a/kratos.gid/apps/DEM/start.tcl
+++ b/kratos.gid/apps/DEM/start.tcl
@@ -177,6 +177,13 @@ proc ::DEM::AfterSaveModel { filespd } {
     }
 }
 
+proc ::DEM::AfterRunCalculation {basename dir problemtypedir where error errorfilename} {
+    # Available parameters
+    #W "$basename $dir $problemtypedir $where $error $errorfilename"
+
+    #return -cancel- ; # To avoid the window
+}
+
 proc ::DEM::PatchMissingSpheresInGroup {filespd} {
     set prj_file [file join [file dirname $filespd] [file rootname $filespd].prj]
     if {[file exists $prj_file]} {

--- a/kratos.gid/kratos.tcl
+++ b/kratos.gid/kratos.tcl
@@ -63,6 +63,7 @@ proc Kratos::RegisterGiDEvents { } {
     # Write - Calculation
     GiD_RegisterEvent GiD_Event_AfterWriteCalculationFile Kratos::Event_AfterWriteCalculationFile PROBLEMTYPE Kratos
     GiD_RegisterEvent GiD_Event_BeforeRunCalculation Kratos::Event_BeforeRunCalculation PROBLEMTYPE Kratos
+    GiD_RegisterEvent GiD_Event_AfterRunCalculation Kratos::Event_AfterRunCalculation PROBLEMTYPE Kratos
 
     # Postprocess
     GiD_RegisterEvent GiD_Event_InitGIDPostProcess Kratos::Event_InitGIDPostProcess PROBLEMTYPE Kratos
@@ -492,6 +493,11 @@ proc Kratos::Event_ChangedLanguage  { newlan } {
 
 proc Kratos::Event_ModifyPreferencesWindow { root } {
     Kratos::ModifyPreferencesWindow $root
+}
+
+proc Kratos::Event_AfterRunCalculation {basename dir problemtypedir where error errorfilename} {
+    # W "$basename $dir $problemtypedir $where $error $errorfilename"
+    return [apps::ExecuteOnCurrentApp AfterRunCalculation $basename $dir $problemtypedir $where $error $errorfilename]
 }
 
 proc Kratos::Quicktest {example_app example_dim example_cmd} {


### PR DESCRIPTION
This PR allows the apps to remove the windows after the calculation process
And sets the DEM app as example:

Caution:
- Works with 15.1.0d and later
- Also removes the error window if the calculation process went wrong.

@maceligueta @farrufat-cimne 