### PR TITLE
[Fluid] Fluid fixes and weakly compressible element addition

### DIFF
--- a/kratos.gid/apps/Buoyancy/xml/ConstitutiveLaws.xml
+++ b/kratos.gid/apps/Buoyancy/xml/ConstitutiveLaws.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ConstitutiveLaws>
-    <CLaw n="Newtonian2DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid" App="Fluid" ImplementedInApplication="FluidDynamicsApplication" Dimension="2D">
+    <!--Newtonian constitutive laws-->
+    <CLaw n="Newtonian2DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid" App="Fluid" ElementCompressibility="Incompressible" ImplementedInApplication="FluidDynamicsApplication" Dimension="2D">
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="1.225"/>
             <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" unit_magnitude="M/(L*T)" units="kg/(m*s)" v="1.846e-5" help="Set the dynamic viscosity."/>
@@ -11,7 +12,7 @@
         </outputs>
     </CLaw>
 
-    <CLaw n="Newtonian3DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid" App="Fluid" ImplementedInApplication="FluidDynamicsApplication" Dimension="3D">
+    <CLaw n="Newtonian3DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid" App="Fluid" ElementCompressibility="Incompressible" ImplementedInApplication="FluidDynamicsApplication" Dimension="3D">
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="1.225"/>
             <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" unit_magnitude="M/(L*T)" units="kg/(m*s)" v="1.846e-5" help="Set the dynamic viscosity."/>
@@ -21,4 +22,30 @@
         <outputs>
         </outputs>
     </CLaw>
+
+    <!--Newtonian with sound velocity constitutive laws-->
+    <CLaw n="WeaklyCompressibleNewtonian2DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid with sound velocity for weak compressibility" App="Fluid" ElementCompressibility="WeaklyCompressible" ImplementedInApplication="FluidDynamicsApplication" Dimension="2D" KratosName="Newtonian2DLaw">
+        <inputs>
+            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="1.225"/>
+            <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" unit_magnitude="M/(L*T)" units="kg/(m*s)" v="1.846e-5" help="Set the dynamic viscosity."/>
+            <parameter n="SOUND_VELOCITY" pn="Sound velocity" unit_magnitude="L/T" units="m/s" v="1.0e+12" help="Set the sound velocity."/>
+            <parameter n="CONDUCTIVITY" pn="Thermal conductivity" unit_magnitude="Power/(L*Temp)" units="W/(m*K)" v="0.024"/>
+            <parameter n="SPECIFIC_HEAT" pn="Specific heat" unit_magnitude="Energy/(M*Temp)" units="J/(kg*K)" v="1012.0"/>
+        </inputs>
+        <outputs>
+        </outputs>
+    </CLaw>
+
+    <CLaw n="WeaklyCompressibleNewtonian3DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid with sound velocity for weak compressibility" App="Fluid" ElementCompressibility="WeaklyCompressible" ImplementedInApplication="FluidDynamicsApplication" Dimension="3D" KratosName="Newtonian3DLaw">
+        <inputs>
+            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="1.225"/>
+            <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" unit_magnitude="M/(L*T)" units="kg/(m*s)" v="1.846e-5" help="Set the dynamic viscosity."/>
+            <parameter n="SOUND_VELOCITY" pn="Sound velocity" unit_magnitude="L/T" units="m/s" v="1.0e+12" help="Set the sound velocity."/>
+            <parameter n="CONDUCTIVITY" pn="Thermal conductivity" unit_magnitude="Power/(L*Temp)" units="W/(m*K)" v="0.024"/>
+            <parameter n="SPECIFIC_HEAT" pn="Specific heat" unit_magnitude="Energy/(M*Temp)" units="J/(kg*K)" v="1012.0"/>
+        </inputs>
+        <outputs>
+        </outputs>
+    </CLaw>
+
 </ConstitutiveLaws>

--- a/kratos.gid/apps/Buoyancy/xml/Materials.xml
+++ b/kratos.gid/apps/Buoyancy/xml/Materials.xml
@@ -6,6 +6,7 @@
       <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" v="1.846e-5" unit_magnitude="M/(L*T)" units="kg/(m*s)"/>
       <parameter n="CONDUCTIVITY" pn="Thermal conductivity" v="0.024" unit_magnitude="Power/(L*Temp)" units="W/(m*K)"/>
       <parameter n="SPECIFIC_HEAT" pn="Specific heat" v="1012.0" unit_magnitude="Energy/(M*Temp)" units="J/(kg*K)"/>
+      <parameter n="SOUND_VELOCITY" pn="Sound velocity" v="3.43e+2" unit_magnitude="L/T" units="m/s"/>
     </inputs>
   </Material>
   <Material n="Water" MaterialType="Fluid" help="Water physical properties">
@@ -14,6 +15,7 @@
       <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" v="1.002e-3" unit_magnitude="M/(L*T)" units="kg/(m*s)"/>
       <parameter n="CONDUCTIVITY" pn="Thermal conductivity" v="0.58" unit_magnitude="Power/(L*Temp)" units="W/(m*K)"/>
       <parameter n="SPECIFIC_HEAT" pn="Specific heat" v="4181.3" unit_magnitude="Energy/(M*Temp)" units="J/(kg*K)"/>
+      <parameter n="SOUND_VELOCITY" pn="Sound velocity" v="1.481e+3" unit_magnitude="L/T" units="m/s"/>
     </inputs>
   </Material>
 </Materials>

--- a/kratos.gid/apps/Fluid/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/Fluid/write/writeProjectParameters.tcl
@@ -240,17 +240,20 @@ proc Fluid::write::getSolverSettingsDict { } {
         # Set OSS and remove oss_switch from the original dictionary
         # It is important to check that there is oss_switch, otherwise the derived apps (e.g. embedded) might crash
         if {[dict exists $solverSettingsDict oss_switch]} {
-            dict set formulationSettingsDict use_orthogonal_subscales [write::getStringBinaryFromValue [dict get $solverSettingsDict oss_switch]]
+            # Set the oss_switch only in those elements that support it
+            if {$element_type eq "qsvms" || $element_type eq "dvms"} {
+                dict set formulationSettingsDict use_orthogonal_subscales [write::getStringBinaryFromValue [dict get $solverSettingsDict oss_switch]]
+            }
+            # Always remove the oss_switch from the original dictionary
             dict unset solverSettingsDict oss_switch
         }
 
-        # Set dynamic tau and remove dynamic_tau from the original dictionary
-        if {$element_type eq "qsvms"} {
-            dict set formulationSettingsDict dynamic_tau [dict get $solverSettingsDict dynamic_tau]
-            dict unset solverSettingsDict dynamic_tau
-            # Include the formulation settings in the solver settings dict
-            dict set solverSettingsDict formulation $formulationSettingsDict
-        }
+        # Set dynamic tau and remove it from the original dictionary
+        dict set formulationSettingsDict dynamic_tau [dict get $solverSettingsDict dynamic_tau]
+        dict unset solverSettingsDict dynamic_tau
+
+        # Include the formulation settings in the solver settings dict
+        dict set solverSettingsDict formulation $formulationSettingsDict
     }
 
     return $solverSettingsDict

--- a/kratos.gid/apps/Fluid/xml/ConstitutiveLaws.xml
+++ b/kratos.gid/apps/Fluid/xml/ConstitutiveLaws.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ConstitutiveLaws>
     <!--Newtonian constitutive laws-->
-	<CLaw n="Newtonian2DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid" App="Fluid" ImplementedInApplication="FluidDynamicsApplication" Dimension="2D">
+	<CLaw n="Newtonian2DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid" App="Fluid" ElementCompressibility="Incompressible" ImplementedInApplication="FluidDynamicsApplication" Dimension="2D">
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="1.225"/>
             <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" unit_magnitude="M/(L*T)" units="kg/(m*s)" v="1.846e-5" help="Set the dynamic viscosity."/>
@@ -10,10 +10,31 @@
         </outputs>
     </CLaw>
 
-	<CLaw n="Newtonian3DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid" App="Fluid" ImplementedInApplication="FluidDynamicsApplication" Dimension="3D">
+	<CLaw n="Newtonian3DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid" App="Fluid" ElementCompressibility="Incompressible" ImplementedInApplication="FluidDynamicsApplication" Dimension="3D">
         <inputs>
             <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="1.225"/>
             <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" unit_magnitude="M/(L*T)" units="kg/(m*s)" v="1.846e-5" help="Set the dynamic viscosity."/>
+        </inputs>
+        <outputs>
+        </outputs>
+    </CLaw>
+
+    <!--Newtonian with sound velocity constitutive laws-->
+	<CLaw n="WeaklyCompressibleNewtonian2DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid with sound velocity for weak compressibility" App="Fluid" ElementCompressibility="WeaklyCompressible" ImplementedInApplication="FluidDynamicsApplication" Dimension="2D" KratosName="Newtonian2DLaw">
+        <inputs>
+            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="1.225"/>
+            <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" unit_magnitude="M/(L*T)" units="kg/(m*s)" v="1.846e-5" help="Set the dynamic viscosity."/>
+            <parameter n="SOUND_VELOCITY" pn="Sound velocity" unit_magnitude="L/T" units="m/s" v="1.0e+12" help="Set the sound velocity."/>
+        </inputs>
+        <outputs>
+        </outputs>
+    </CLaw>
+
+	<CLaw n="WeaklyCompressibleNewtonian3DLaw" pn="Newtonian" ProductionReady="ProductionReady" help="Newtonian fluid with sound velocity for weak compressibility" App="Fluid" ElementCompressibility="WeaklyCompressible" ImplementedInApplication="FluidDynamicsApplication" Dimension="3D" KratosName="Newtonian3DLaw">
+        <inputs>
+            <parameter n="DENSITY" pn="Density" unit_magnitude="Density" units="kg/m^3" v="1.225"/>
+            <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" unit_magnitude="M/(L*T)" units="kg/(m*s)" v="1.846e-5" help="Set the dynamic viscosity."/>
+            <parameter n="SOUND_VELOCITY" pn="Sound velocity" unit_magnitude="L/T" units="m/s" v="1.0e+12" help="Set the sound velocity."/>
         </inputs>
         <outputs>
         </outputs>

--- a/kratos.gid/apps/Fluid/xml/Elements.xml
+++ b/kratos.gid/apps/Fluid/xml/Elements.xml
@@ -10,6 +10,7 @@
 
     <ConstitutiveLaw_FilterFeatures>
       <filter field="App" value="Fluid"/>
+      <filter field="ElementCompressibility" value="Incompressible"/>
     </ConstitutiveLaw_FilterFeatures>
 
     <!--define list of NodalConditions-->
@@ -33,6 +34,7 @@
     </TopologyFeatures>
     <ConstitutiveLaw_FilterFeatures>
       <filter field="App" value="Fluid"/>
+      <filter field="ElementCompressibility" value="Incompressible"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
     <NodalConditions>
@@ -58,6 +60,7 @@
 
         <ConstitutiveLaw_FilterFeatures>
             <filter field="App" value="Fluid"/>
+            <filter field="ElementCompressibility" value="Incompressible"/>
         </ConstitutiveLaw_FilterFeatures>
 
         <!--define list of NodalConditions-->
@@ -85,6 +88,7 @@
 
         <ConstitutiveLaw_FilterFeatures>
             <filter field="App" value="Fluid"/>
+            <filter field="ElementCompressibility" value="Incompressible"/>
         </ConstitutiveLaw_FilterFeatures>
 
         <!--define list of NodalConditions-->
@@ -112,6 +116,7 @@
 
         <ConstitutiveLaw_FilterFeatures>
             <filter field="App" value="Fluid"/>
+            <filter field="ElementCompressibility" value="Incompressible"/>
         </ConstitutiveLaw_FilterFeatures>
 
         <!--define list of NodalConditions-->
@@ -139,6 +144,7 @@
 
         <ConstitutiveLaw_FilterFeatures>
             <filter field="App" value="Fluid"/>
+            <filter field="ElementCompressibility" value="Incompressible"/>
         </ConstitutiveLaw_FilterFeatures>
 
         <!--define list of NodalConditions-->
@@ -166,6 +172,7 @@
 
         <ConstitutiveLaw_FilterFeatures>
             <filter field="App" value="Fluid"/>
+            <filter field="ElementCompressibility" value="Incompressible"/>
         </ConstitutiveLaw_FilterFeatures>
 
         <!--define list of NodalConditions-->
@@ -193,6 +200,7 @@
 
         <ConstitutiveLaw_FilterFeatures>
             <filter field="App" value="Fluid"/>
+            <filter field="ElementCompressibility" value="Incompressible"/>
         </ConstitutiveLaw_FilterFeatures>
 
         <!--define list of NodalConditions-->
@@ -219,6 +227,7 @@
 
         <ConstitutiveLaw_FilterFeatures>
             <filter field="App" value="Fluid"/>
+            <filter field="ElementCompressibility" value="WeaklyCompressible"/>
         </ConstitutiveLaw_FilterFeatures>
 
         <!--define list of NodalConditions-->
@@ -245,6 +254,7 @@
 
         <ConstitutiveLaw_FilterFeatures>
             <filter field="App" value="Fluid"/>
+            <filter field="ElementCompressibility" value="WeaklyCompressible"/>
         </ConstitutiveLaw_FilterFeatures>
 
         <!--define list of NodalConditions-->

--- a/kratos.gid/apps/Fluid/xml/Elements.xml
+++ b/kratos.gid/apps/Fluid/xml/Elements.xml
@@ -214,7 +214,6 @@
         <!--here we could add a list of all of the possible geometries-->
         <TopologyFeatures>
             <item GeometryType="Triangle" nodes="3" KratosName="Element2D3N"/>
-            <!-- <item GeometryType="Quadrilateral" nodes="4" KratosName="Element2D4N"/> -->
         </TopologyFeatures>
         <!-- here we add the block of features which we require from the constitutive law-->
 
@@ -241,7 +240,6 @@
         <!--here we could add a list of all of the possible geometries-->
         <TopologyFeatures>
             <item GeometryType="Tetrahedra" nodes="4" KratosName="Element3D4N"/>
-            <!-- <item GeometryType="Hexahedra" nodes="8" KratosName="Element3D8N"/> -->
         </TopologyFeatures>
         <!-- here we add the block of features which we require from the constitutive law-->
 

--- a/kratos.gid/apps/Fluid/xml/Elements.xml
+++ b/kratos.gid/apps/Fluid/xml/Elements.xml
@@ -208,4 +208,58 @@
         </outputs>
     </ElementItem>
 
+    <ElementItem n="WeaklyCompressible2D" pn="Weakly compressible" ImplementedInFile="weakly_compressible_navier_stokes.cpp" ImplementedInApplication="FluidDynamicsApplication"  FormulationElementType="weakly_compressible"
+        MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="2D" LocalSpaceDimension="2" RequiresLocalAxes="False"
+        LargeDeformation="False" ElementType="Fluid" help="This element implements a VMS stabilized weakly compressible Navier-Stokes monolithic formulation">
+        <!--here we could add a list of all of the possible geometries-->
+        <TopologyFeatures>
+            <item GeometryType="Triangle" nodes="3" KratosName="Element2D3N"/>
+            <!-- <item GeometryType="Quadrilateral" nodes="4" KratosName="Element2D4N"/> -->
+        </TopologyFeatures>
+        <!-- here we add the block of features which we require from the constitutive law-->
+
+        <ConstitutiveLaw_FilterFeatures>
+            <filter field="App" value="Fluid"/>
+        </ConstitutiveLaw_FilterFeatures>
+
+        <!--define list of NodalConditions-->
+        <NodalConditions>
+            <NodalCondition n="VELOCITY"/>
+            <NodalCondition n="PRESSURE"/>
+        </NodalConditions>
+
+        <inputs>
+        </inputs>
+
+        <outputs>
+        </outputs>
+    </ElementItem>
+
+    <ElementItem n="WeaklyCompressible3D" pn="Weakly compressible" ImplementedInFile="weakly_compressible_navier_stokes.cpp" ImplementedInApplication="FluidDynamicsApplication" FormulationElementType="weakly_compressible"
+        MinimumKratosVersion="9000" ProductionReady="ProductionReady" WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False"
+        LargeDeformation="False" ElementType="Fluid" help="This element implements a VMS stabilized weakly compressible Navier-Stokes monolithic formulation">
+        <!--here we could add a list of all of the possible geometries-->
+        <TopologyFeatures>
+            <item GeometryType="Tetrahedra" nodes="4" KratosName="Element3D4N"/>
+            <!-- <item GeometryType="Hexahedra" nodes="8" KratosName="Element3D8N"/> -->
+        </TopologyFeatures>
+        <!-- here we add the block of features which we require from the constitutive law-->
+
+        <ConstitutiveLaw_FilterFeatures>
+            <filter field="App" value="Fluid"/>
+        </ConstitutiveLaw_FilterFeatures>
+
+        <!--define list of NodalConditions-->
+        <NodalConditions>
+            <NodalCondition n="VELOCITY"/>
+            <NodalCondition n="PRESSURE"/>
+        </NodalConditions>
+
+        <inputs>
+        </inputs>
+
+        <outputs>
+        </outputs>
+    </ElementItem>
+
 </ElementList>

--- a/kratos.gid/apps/Fluid/xml/Materials.xml
+++ b/kratos.gid/apps/Fluid/xml/Materials.xml
@@ -4,12 +4,14 @@
     <inputs>
         <parameter n="DENSITY" pn="Density" v="1.225" unit_magnitude="Density" units="kg/m^3"/>
         <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" v="1.846e-5" unit_magnitude="M/(L*T)" units="kg/(m*s)"/>
+        <parameter n="SOUND_VELOCITY" pn="Sound velocity" v="3.43e+2" unit_magnitude="L/T" units="m/s"/>
     </inputs>
   </Material>
   <Material n="Water" MaterialType="Fluid" help="Water physical properties" icon="drop">
     <inputs>
         <parameter n="DENSITY" pn="Density" v="1000" unit_magnitude="Density" units="kg/m^3"/>
         <parameter n="DYNAMIC_VISCOSITY" pn="Dynamic viscosity" v="1.002e-3" unit_magnitude="M/(L*T)" units="kg/(m*s)"/>
+        <parameter n="SOUND_VELOCITY" pn="Sound velocity" v="1.481e+3" unit_magnitude="L/T" units="m/s"/>
     </inputs>
   </Material>
 </Materials>

--- a/kratos.gid/apps/Fluid/xml/Strategies.xml
+++ b/kratos.gid/apps/Fluid/xml/Strategies.xml
@@ -50,7 +50,7 @@
 			<scheme n="bdf2" pn="BDF2" help="2nd order Backward Differenctiation Formula (BDF2) scheme for CFD problems." ProductionReady="ProductionReady">
                 <parameter_list></parameter_list>
                 <element_filters>
-                    <filter field="n" value="QSVMS2D,QSVMS3D,DVMS2D,DVMS3D,FIC2D,FIC3D"/>
+                    <filter field="n" value="QSVMS2D,QSVMS3D,DVMS2D,DVMS3D,FIC2D,FIC3D,WeaklyCompressible2D,WeaklyCompressible3D"/>
                 </element_filters>
             </scheme>
 		</schemes>

--- a/kratos.gid/apps/FluidDEM/xml/Elements.xml
+++ b/kratos.gid/apps/FluidDEM/xml/Elements.xml
@@ -24,6 +24,7 @@
     </TopologyFeatures>
     <ConstitutiveLaw_FilterFeatures>
       <filter field="App" value="Fluid"/>
+      <filter field="ElementCompressibility" value="Incompressible"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
     <NodalConditions>
@@ -46,6 +47,7 @@
 
     <ConstitutiveLaw_FilterFeatures>
       <filter field="App" value="Fluid"/>
+      <filter field="ElementCompressibility" value="Incompressible"/>
     </ConstitutiveLaw_FilterFeatures>
 
     <!--define list of NodalConditions-->


### PR DESCRIPTION
This PR fixes some inconsistencies in the `formulation` dictionary. Furthermore it adds the new `WeaklyCompressibleNavierStokes` element to the GUI.

`Buoyancy` and `FluidDEM` applications have been updated accordingly so everything should work fine.

(we need to first merge [7997](https://github.com/KratosMultiphysics/Kratos/pull/7997) in the Kratos main repo).