### PR TITLE
Debug a case execution using VSCode and GiD Interface

### DIFF
--- a/kratos.gid/kratos.tcl
+++ b/kratos.gid/kratos.tcl
@@ -143,6 +143,8 @@ proc Kratos::InitGlobalVariables {dir} {
     set kratos_private(echo_level) 0
     # indent in mdpa files  | 0 ASCII unindented | 1 ASCII indented pretty
     set kratos_private(mdpa_format) 1
+    # kratos debug env for VSCode debug
+    set kratos_private(debug_folder) ""
     # Version of the kratos executable
     set kratos_private(exec_version) "dev"
     # Allow logs -> 0 No | 1 Only local | 2 Share with dev team
@@ -309,6 +311,7 @@ proc Kratos::RestoreVariables { } {
     # Restore GiD variables that kratos modified (maybe the mesher...)
     if {[info exists kratos_private(RestoreVars)]} {
         foreach {k v} $kratos_private(RestoreVars) {
+            # W "$k $v"
             set $k $v
         }
     }

--- a/kratos.gid/scripts/Controllers/Preferences.xml
+++ b/kratos.gid/scripts/Controllers/Preferences.xml
@@ -18,6 +18,7 @@
             <option value='1' label='1'/>
             <option value='2' label='2'/>
         </combobox>
+        <entrywithbutton name="debug_folder" label="Debug path" variable="debug_folder" buttonimage="folder.png" variablemanager='Kratos::ManagePreferences' buttonfunction="OpenBrowserForDirectory" help='Path to the kratos debug folder. This is placed in the launch.json file for debugging' />
     </labelframe>
 </group>
 

--- a/kratos.gid/scripts/Controllers/PreferencesWindow.tcl
+++ b/kratos.gid/scripts/Controllers/PreferencesWindow.tcl
@@ -28,6 +28,9 @@ proc Kratos::ManagePreferences { cmd name {value ""}} {
                 "mdpa_format" {
                     set ret 1
                 }
+                "debug_folder" {
+                    set ret ""
+                }
             }
         }
     }

--- a/kratos.gid/scripts/Menus.tcl
+++ b/kratos.gid/scripts/Menus.tcl
@@ -130,6 +130,7 @@ proc Kratos::ChangeMenus { } {
     GiDMenu::InsertOption "Kratos" [list "Kratos data" ] [incr pos] PRE [list gid_groups_conds::open_conditions menu] "" "" replace =
     GiDMenu::InsertOption "Kratos" [list "Local axes window" ] [incr pos] PRE [list gid_groups_conds::local_axes_window] "" "" replace =
     GiDMenu::InsertOption "Kratos" [list "View spd file" ] [incr pos] PRE [list spdAux::ViewDoc] "" "" replace =
+    GiDMenu::InsertOption "Kratos" [list "Open case in VS Code" ] [incr pos] PRE [list Kratos::OpenCaseIn VSCode] "" "" replace =
     GiDMenu::InsertOption "Kratos" [list "---"] [incr pos] PRE "" "" "" replace =
     GiDMenu::InsertOption "Kratos" [list "Write calculation files - No run" ] [incr pos] PRE [list Kratos::WriteCalculationFilesEvent] "" "" replace =
     GiDMenu::InsertOption "Kratos" [list "Run - No write" ] [incr pos] PRE [list Kratos::ForceRun] "" "" replace =

--- a/kratos.gid/scripts/Utils.tcl
+++ b/kratos.gid/scripts/Utils.tcl
@@ -282,6 +282,9 @@ proc Kratos::OpenCaseIn {program} {
         "VSCode" {
             if {[GiD_Info Project ModelName] eq "UNNAMED"} {W "Save your model first"} {
                 catch {exec code -n [GidUtils::GetDirectoryModel]} msg
+                if {$msg eq {couldn't execute "code": no such file or directory}} {
+                    W "Install Visual Studio Code and add it to your PATH"
+                }
             }
         }
         default {}

--- a/kratos.gid/scripts/Utils.tcl
+++ b/kratos.gid/scripts/Utils.tcl
@@ -152,7 +152,7 @@ proc Kratos::RegisterEnvironment { } {
     #do not save preferences starting with flag gid.exe -c (that specify read only an alternative file)
     if { [GiD_Set SaveGidDefaults] } {
         variable kratos_private
-        set vars_to_save [list DevMode echo_level mdpa_format]
+        set vars_to_save [list DevMode echo_level mdpa_format debug_folder]
         set preferences [dict create]
         foreach v $vars_to_save {
             if {[info exists kratos_private($v)]} {
@@ -179,11 +179,13 @@ proc Kratos::LoadEnvironment { } {
         set fp [open [Kratos::GetPreferencesFilePath] r]
         # Read the preferences
         set data [read $fp]
+        # W $data
         # Close the file
         close $fp
     }
     # Preferences are written in json format
     foreach {k v} [write::json2dict $data] {
+        # W "$k $v"
         # Foreach pair key value, restore it
         set kratos_private($k) $v
     }
@@ -273,4 +275,10 @@ proc Kratos::GetMeshBasicData { } {
 
 proc ? {question true_val false_val} {
     return [expr $question ? $true_val : $false_val]
+}
+
+
+proc xmlprograms::OpenBrowserForDirectory { baseframe variable} {      
+    set $variable [MessageBoxGetFilename directory write [_ "Select kratos debug compiled folder (kratos / bin / debug"]]
+    return variable
 }

--- a/kratos.gid/scripts/Utils.tcl
+++ b/kratos.gid/scripts/Utils.tcl
@@ -277,6 +277,17 @@ proc ? {question true_val false_val} {
     return [expr $question ? $true_val : $false_val]
 }
 
+proc Kratos::OpenCaseIn {program} {
+    switch $program {
+        "VSCode" {
+            if {[GiD_Info Project ModelName] eq "UNNAMED"} {W "Save your model first"} {
+                catch {exec code -n [GidUtils::GetDirectoryModel]} msg
+            }
+        }
+        default {}
+    }
+}
+
 
 proc xmlprograms::OpenBrowserForDirectory { baseframe variable} {      
     set $variable [MessageBoxGetFilename directory write [_ "Select kratos debug compiled folder (kratos / bin / debug"]]


### PR DESCRIPTION
This PR just generates the files to make the life a little bit easier to a VSCode debugger.

- Open the Kratos preferences -> from the main window, or in the top menú Kratos > Preferences
- Select Developer mode
- Pick the Kratos debug compiled folder -> %your_kratos_repository_folder%/Kratos/bin/Debug
- This preferences are stored for future sessions.
- Generate your case, mesh it and write the input files (Click on calculate or Kratos > Write calculation files)
- Open your case folder in Visual Studio Code
- Place a breakpoint somewhere in the MainKratos.py file in the case
- Click on the debug tab, and run the python main configuration.
- When it hits the breakpoint, you can also attach the c++ debugger (see how at the end of the video)

https://user-images.githubusercontent.com/5918085/125700106-64e92306-e5ee-4008-b9a4-9815085cca3a.mp4

@KratosMultiphysics/team-maintainers 
@maceligueta 
