### PR TITLE
Condition only existing groups

### DIFF
--- a/kratos.gid/scripts/Controllers/TreeInjections.tcl
+++ b/kratos.gid/scripts/Controllers/TreeInjections.tcl
@@ -234,7 +234,11 @@ proc spdAux::_injectCondsToTree {basenode cond_list {cond_type "normal"} args } 
             set state [$cnd getAttribute state]
             if {$state eq ""} {set state "CheckNodalConditionState"}
         }
-        set node "<condition n='$n' pn='$pn' ov='$etype' ovm='' icon='shells16' help='$help' state='\[$state\]' update_proc='\[OkNewCondition\]' check='$check'>"
+        set allow_group_creation ""
+        if {[$cnd getAttribute Groups] ne ""} {
+            set allow_group_creation "allow_group_creation='0' groups_list='\[[$cnd getAttribute Groups]\]'"
+        }
+        set node "<condition n='$n' pn='$pn' ov='$etype' ovm='' icon='shells16' help='$help' state='\[$state\]' update_proc='\[OkNewCondition\]' check='$check' $allow_group_creation>"
         set symbol_data [$cnd getSymbol]
         if { [llength $symbol_data] } {
             set txt "<symbol"


### PR DESCRIPTION
This PR enables the new GiD feature (15.1.4d) to configure conditions:

When double click on a condition, dont allow the creation of new groups. Execute a tcl proc to return a group list, so the user can select from that list. Useful in the new @KratosMultiphysics/dem  app

Copy and pase this sections to see the changes (I don't add them to the PR because we dont want them to exist yet)
- file `kratos.gid/apps/DEM/xml/Conditions.xml` line 21: 
```xml
 <ConditionItem n="DEM-FEM-Wall2D" pn="Rigid Walls" Interval="False" 
ImplementedInApplication="DEMApplication" MinimumKratosVersion="9000" 
ProductionReady="ProductionReady" WorkingSpaceDimension="2D" 
LocalSpaceDimension="1" ElementType="Line" ProcessName="DEM-FEM-Wall-Process" 
help="Assign kinematic conditions for each group containing finite elements" VariableName="WALL" 
Groups="GetPartsGroupsList">
```
Just add `Groups="GetPartsGroupsList"`

- file `kratos.gid/apps/DEM/xml/Procs.spd` add:
```xml
<proc n='GetPartsGroupsList' args='args'>
     <![CDATA[
    return [DEM::xml::ProcGetPartsGroupsList $domNode $args]
    ]]>
</proc>
```
- file `kratos.gid/apps/DEM/xml/XmlController.tcl` add:
```tcl
proc ::DEM::xml::ProcGetPartsGroupsList {domNode args} {
    return [list a b]
}
```

This will change the condition and allows us only to pick from existing groups

![image](https://user-images.githubusercontent.com/5918085/142009853-8b85afc6-ed51-4149-bd23-b128ca127f04.png)
![image](https://user-images.githubusercontent.com/5918085/142009915-e4d51758-6a0b-456f-9dc2-b95fcb412c6b.png)


@maceligueta @farrufat-cimne 
