### PR TITLE
Gid output folder

### DIFF
--- a/kratos.gid/apps/Common/xml/Results.spd
+++ b/kratos.gid/apps/Common/xml/Results.spd
@@ -14,6 +14,7 @@
             <dependencies value="Yes" node="../container" att1="state" v1="normal"/>
         </value>
         <container n="GiDOptions" pn="Options" un="GiDOptions" help="GiD postprocess options" open_window="1" icon="options">
+            <value n="FolderName" pn="Folder name" v="gid_output" help="This folder will be created to store the GiD results" />
             <value n="FileLabel" pn="File Label" v="step" values="time,step" dict="time,Time,step,Step" help=""/>
             <value n="OutputControlType" pn="Units used for output frequency" v="step" values="time,step" dict="time,Time (s),step,Steps" help="" update_proc="spdAux::RequestRefresh">
                 <dependencies node="../value" actualize="1"/>
@@ -23,7 +24,6 @@
             <value n="BodyOutput" pn="Body output" v="Yes" values="Yes,No" help="The interior of the volume is printed" state="[ShowInMode Developer]"/>
             <value n="NodeOutput" pn="Node output" v="No" values="Yes,No" help="The nodes are printed as a separate layer" state="[ShowInMode Developer]"/>
             <value n="SkinOutput" pn="Skin output" v="No" values="Yes,No" help="" state="[ShowInMode Developer]"/>
-
             <value n="GiDPostMode" pn="Result format" v="GiD_PostBinary" values="GiD_PostBinary,GiD_PostAscii,GiD_PostAsciiZipped" dict="GiD_PostBinary,Binary,GiD_PostAscii,Ascii,GiD_PostAsciiZipped,Ascii zipped" help="GiD result file format" />
             <value n="GiDWriteMeshFlag" pn="Write deformed mesh" v="WriteDeformed" values="WriteDeformed,WriteUndeformed" dict="WriteDeformed,Write deformed,WriteUndeformed, Write undeformed" help="Write the GiD deformed or undeformed mesh"/>
             <value n="GiDWriteConditionsFlag" pn="Write conditions" v="WriteConditions" values="WriteConditions,WriteElementsOnly,WriteConditionsOnly" dict="WriteConditions,Write conditions,WriteElementsOnly,Write elements only,WriteConditionsOnly,Write conditions only" help="Write the conditions or only element to the GiD result file"/>

--- a/kratos.gid/scripts/Writing/WriteProjectParameters.tcl
+++ b/kratos.gid/scripts/Writing/WriteProjectParameters.tcl
@@ -258,7 +258,7 @@ proc write::getConditionsParametersDict {un {condition_type "Condition"}} {
             set process [::Model::GetProcess $processName]
             set processDict [dict create]
             set processWriteCommand [$process getAttribute write_command]
-            
+
             dict set processDict process_name $processName
 
             if {$processWriteCommand eq ""} {
@@ -268,7 +268,7 @@ proc write::getConditionsParametersDict {un {condition_type "Condition"}} {
                 foreach {inputName in_obj} $process_parameters {
                     dict set processDict Parameters $inputName [write::GetInputValue $group $in_obj]
                 }
-                
+
             } else {
                 set processDict [$processWriteCommand $group $condition $process]
             }
@@ -447,7 +447,7 @@ proc write::GetDefaultGiDOutput { {appid ""} } {
     # Setup GiD-Output
     set outputProcessParams [dict create]
     dict set outputProcessParams model_part_name [write::GetModelPartNameWithParent [GetConfigurationAttribute output_model_part_name]]
-    dict set outputProcessParams output_name $model_name
+    dict set outputProcessParams output_name [file join "gid_output" $model_name]
     dict set outputProcessParams postprocess_parameters [write::GetDefaultOutputGiDDict $appid]
 
     set outputConfigDict [dict create]

--- a/kratos.gid/scripts/Writing/WriteProjectParameters.tcl
+++ b/kratos.gid/scripts/Writing/WriteProjectParameters.tcl
@@ -447,8 +447,10 @@ proc write::GetDefaultGiDOutput { {appid ""} } {
     # Setup GiD-Output
     set outputProcessParams [dict create]
     dict set outputProcessParams model_part_name [write::GetModelPartNameWithParent [GetConfigurationAttribute output_model_part_name]]
-    dict set outputProcessParams output_name [file join "gid_output" $model_name]
     dict set outputProcessParams postprocess_parameters [write::GetDefaultOutputGiDDict $appid]
+    set folder_name [dict get $outputProcessParams postprocess_parameters folder_name]
+    dict unset outputProcessParams postprocess_parameters folder_name
+    dict set outputProcessParams output_name [file join $folder_name $model_name]
 
     set outputConfigDict [dict create]
     dict set outputConfigDict python_module gid_output_process
@@ -497,6 +499,8 @@ proc write::GetDefaultOutputGiDDict { {appid ""} {gid_options_xpath ""} } {
 
     dict set outputDict "result_file_configuration" $resultDict
     dict set outputDict "point_data_configuration" [GetEmptyList]
+
+    dict set outputDict folder_name [getValueByXPath $gid_options_xpath FolderName]
     return $outputDict
 }
 


### PR DESCRIPTION
This field allows apps to store the postprocess files into a folder easily

VTK output stores the files in vtk_output, so they don't disturb the model files

This PR adds a field in the GUI
![image](https://user-images.githubusercontent.com/5918085/152402178-2489bea7-9d0d-4e56-a151-b01c2e563976.png)

So all the postprocess files will be created inside a folder (except the .post.lst one, that must be on the root)


![image](https://user-images.githubusercontent.com/5918085/152401977-89654905-0f12-4fdb-b31c-98ef572b62e3.png)

The effect on the ProjectParameters.json section is that the output_name has the folder prepended:
```json
"gid_output" : [{
            "python_module" : "gid_output_process",
            "kratos_module" : "KratosMultiphysics",
            "process_name"  : "GiDOutputProcess",
            "help"          : "This process writes postprocessing files for GiD",
            "Parameters"    : {
                "model_part_name"        : "FluidModelPart.fluid_computational_model_part",
                *"output_name"            : "gid_output/folder",*
                "postprocess_parameters" : {
                    "result_file_configuration" : {
                        "gidpost_flags"               : {
                            "GiDPostMode"           : "GiD_PostBinary",
                            "WriteDeformedMeshFlag" : "WriteDeformed",
                            "WriteConditionsFlag"   : "WriteConditions",
                            "MultiFileFlag"         : "MultipleFiles"
                        },
                        "file_label"                  : "time",
                        "output_control_type"         : "step",
                        "output_interval"             : 1,
                        "body_output"                 : true,
                        "node_output"                 : false,
                        "skin_output"                 : false,
                        "plane_output"                : [],
                        "nodal_results"               : ["VELOCITY","PRESSURE","TEMPERATURE"],
                        "gauss_point_results"         : [],
                        "nodal_nonhistorical_results" : []
                    },
                    "point_data_configuration"  : []
                }
            }
        }]
```

@KratosMultiphysics/technical-committee 
I hope this works also in MPI