### PR TITLE
Hotfix linear topologies

### DIFF
--- a/kratos.gid/scripts/Model/Condition.tcl
+++ b/kratos.gid/scripts/Model/Condition.tcl
@@ -5,7 +5,7 @@
 
 namespace eval ::Model {
     Kratos::AddNamespace [namespace current]
-    
+
 catch {Condition destroy}
 oo::class create Condition {
     superclass Entity
@@ -14,32 +14,32 @@ oo::class create Condition {
     variable defaults
     variable groupby
     variable symbol
-        
+
     constructor {n} {
         next $n
         variable TopologyFeatures
         set TopologyFeatures [list ]
-        
+
         variable defaults
         set defaults [dict create ]
-        
+
         variable processName
         set processName ""
         variable groupby
         set groupby ""
         set symbol [list]
     }
-    
+
     method addTopologyFeature {top} {
         variable TopologyFeatures
         lappend TopologyFeatures $top
     }
-    
+
     method getTopologyFeature {geo nod} {
         variable TopologyFeatures
         set ret ""
         foreach top $TopologyFeatures {
-            if {[string match [$top getGeometry]* $geo] && [$top getNodes] eq $nod} {set ret $top; break}
+            if {[$top getGeometry] eq $geo && [$top getNodes] eq $nod} {set ret $top; break}
         }
         return $ret
     }
@@ -59,7 +59,7 @@ oo::class create Condition {
         variable TopologyFeatures
         return $TopologyFeatures
     }
-    
+
     method setProcessName {pn} {
         variable processName
         set processName $pn
@@ -128,17 +128,17 @@ proc Model::DeleteRepeatedConditions { } {
     variable Conditions
     set Conditions2 [dict create ]
     foreach cnd $Conditions {
-        set cnd_id [$cnd getName] 
+        set cnd_id [$cnd getName]
         dict set Conditions2 $cnd
     }
     set Conditions $Conditions2
 }
-proc Model::GetConditions {args} { 
+proc Model::GetConditions {args} {
     variable Conditions
     if {$args eq ""} {
         return $Conditions
     }
-    
+
     set cumplen [list ]
     foreach elem $Conditions {
         if {[$elem cumple {*}$args]} { lappend cumplen $elem}
@@ -149,7 +149,7 @@ proc Model::GetConditions {args} {
 
 proc Model::ParseConditions { doc } {
     variable Conditions
-    
+
     set CondNodeList [$doc getElementsByTagName ConditionItem]
     foreach CondNode $CondNodeList {
         lappend Conditions [ParseCondNode $CondNode]
@@ -164,7 +164,7 @@ proc Model::ParseCondNode { node } {
     if {[$node hasAttribute help]} {$cnd setHelp [$node getAttribute help]}
     if {[$node hasAttribute ProcessName]} {$cnd setProcessName [$node getAttribute ProcessName]}
     if {[$node hasAttribute GroupBy]} {$cnd setGroupBy [$node getAttribute GroupBy]}
-    
+
     foreach att [$node attributes] {
         $cnd setAttribute $att [split [$node getAttribute $att] ","]
         #W "$att : [$el getAttribute $att]"
@@ -173,11 +173,11 @@ proc Model::ParseCondNode { node } {
     if { [llength $symbol_node]==1 } {
         set data [list]
         foreach attribute [$symbol_node attributes] {
-            lappend data $attribute [$symbol_node getAttribute $attribute]            
+            lappend data $attribute [$symbol_node getAttribute $attribute]
         }
         $cnd setSymbol $data
     }
-    
+
     set topology_base [$node getElementsByTagName TopologyFeatures]
     if {[llength $topology_base] eq 1} {
         foreach top [$topology_base getElementsByTagName item]  {
@@ -214,7 +214,7 @@ proc Model::ParseCondNode { node } {
     return $cnd
 }
 
-proc Model::getCondition {cid} { 
+proc Model::getCondition {cid} {
     variable Conditions
 
     foreach elem $Conditions {
@@ -227,7 +227,7 @@ proc Model::getCondition {cid} {
 
 proc Model::GetAllCondOutputs {} {
     variable Conditions
-    
+
     set outputs [dict create]
     foreach el $Conditions {
         foreach in [dict keys [$el getOutputs]] {
@@ -239,7 +239,7 @@ proc Model::GetAllCondOutputs {} {
 
 proc Model::GetAllCondInputs {} {
     variable Conditions
-    
+
     set inputs [dict create]
     foreach el $Conditions {
         foreach in [dict keys [$el getInputs]] {
@@ -264,7 +264,7 @@ proc Model::CheckConditionState {node args} {
                     set eldim [split [$cond getAttribute "WorkingSpaceDimension"] ","]
                     if {$ptdim ni $eldim} {set cumple 0; break}
                 }
-             
+
             }
         }
     }

--- a/kratos.gid/scripts/Model/Element.tcl
+++ b/kratos.gid/scripts/Model/Element.tcl
@@ -7,26 +7,26 @@ namespace eval ::Model {
 catch {Element destroy}
 oo::class create Element {
     superclass Entity
-    
+
     variable TopologyFeatures
     variable ElementNodalCondition
     variable constLawFilters
-    
+
     constructor {n} {
         next $n
         variable TopologyFeatures
         variable ElementNodalCondition
         variable constLawFilters
-        
+
         set TopologyFeatures [list ]
         set ElementNodalCondition [list ]
         set constLawFilters [dict create]
     }
-    
+
     method addConstLawFilter {key value} {variable constLawFilters; dict set constLawFilters $key $value}
     method getConstLawFilterValue {key} {
         variable constLawFilters;
-        
+
         set v ""
         if {[dict exists $constLawFilters $key]} {
             set v [dict get $constLawFilters $key]
@@ -35,16 +35,16 @@ oo::class create Element {
     }
     method getConstLawFilters {} {
         variable constLawFilters
-        
+
         set v [list ]
         if {[info exists constLawFilters]} {
             foreach k [dict keys $constLawFilters] {
-                lappend v $k [dict get $constLawFilters $k] 
+                lappend v $k [dict get $constLawFilters $k]
             }
         }
         return $v
     }
-    
+
     method addNodalCondition {nc_name} {
         variable ElementNodalCondition
         lappend ElementNodalCondition $nc_name
@@ -67,10 +67,10 @@ oo::class create Element {
                 return $nc
             }
         }
-        
+
         return $v
     }
-    
+
     method resetTopologies { } {
         variable TopologyFeatures
         set TopologyFeatures [list ]
@@ -82,7 +82,7 @@ oo::class create Element {
     method getTopologyFeature {geo nod} {
         variable TopologyFeatures
         set ret ""
-        foreach top $TopologyFeatures {            
+        foreach top $TopologyFeatures {
             #if {[$top getNodes] eq $nod} {set ret $top; break}
             if {[$top getGeometry] eq $geo && [$top getNodes] eq $nod} {set ret $top; break}
         }
@@ -95,13 +95,13 @@ oo::class create Element {
 
     method cumple {args} {
         set c [next {*}$args]
-         
+
         if {$c} {
             set ptdim $::Model::SpatialDimension
             set eldim [split [my getAttribute "WorkingSpaceDimension"] ","]
             if {$ptdim ni $eldim} {set c 0}
         }
-        
+
         return $c
     }
 }
@@ -109,20 +109,20 @@ catch {NodalCondition destroy}
 oo::class create NodalCondition {
     superclass Condition
     variable reaction
-    variable ov    
-    
+    variable ov
+
     constructor {n} {
         next $n
         set reaction ""
         set ov ""
         #set ov "point,line,surface,volume"
     }
-    
+
     method setReaction {r} {variable reaction; set reaction $r}
     method getReaction {} {variable reaction; return $reaction}
     method setOv {r} {variable ov; set ov $r}
     method getOv {} { variable ov; return $ov}
-    
+
 }
 }
 
@@ -143,7 +143,7 @@ proc Model::ForgetElement { elem_id } {
 
 proc Model::ParseElements { doc } {
     variable Elements
-    
+
     set ElemNodeList [$doc getElementsByTagName ElementItem]
     foreach ElemNode $ElemNodeList {
         lappend Elements [ParseElemNode $ElemNode]
@@ -175,11 +175,11 @@ proc Model::ForgetNodalCondition { cnd_id } {
 
 proc Model::ParseElemNode { node } {
     set name [$node getAttribute n]
-    
+
     set el [::Model::Element new $name]
     $el setPublicName [$node getAttribute pn]
     if {[$node hasAttribute v]} {$el setDv [$node getAttribute v]}
-    
+
     foreach att [$node attributes] {
         $el setAttribute $att [split [$node getAttribute $att] ","]
         #W "$att : [$el getAttribute $att]"
@@ -196,7 +196,7 @@ proc Model::ParseElemNode { node } {
             set el [ParseInputParamNode $el $in]
         }
     }
-    
+
     set outputs_node [$node getElementsByTagName outputs]
     if {$outputs_node ne "" && [$outputs_node hasChildNodes]} {
         foreach out [$outputs_node childNodes] {
@@ -221,7 +221,7 @@ proc Model::ParseElemNode { node } {
             $el addNodalCondition $n
         }
     }
-    
+
     return $el
 }
 proc Model::ParseNodalConditionsNode { node } {
@@ -229,13 +229,13 @@ proc Model::ParseNodalConditionsNode { node } {
     #W "Parsing $name"
     set el [::Model::NodalCondition new $name]
     $el setPublicName [$node getAttribute pn]
-    
+
     if {[$node hasAttribute ov]} {
         set ov [$node getAttribute ov]
         $el setOv $ov
     }
-    
-    
+
+
     foreach att [$node attributes] {
         $el setAttribute $att [split [$node getAttribute $att] ","]
         #W "$att : [$el getAttribute $att]"
@@ -244,7 +244,7 @@ proc Model::ParseNodalConditionsNode { node } {
     if { [llength $symbol_node]==1 } {
         set data [list]
         foreach attribute [$symbol_node attributes] {
-            lappend data $attribute [$symbol_node getAttribute $attribute]            
+            lappend data $attribute [$symbol_node getAttribute $attribute]
         }
         $el setSymbol $data
     }
@@ -254,7 +254,7 @@ proc Model::ParseNodalConditionsNode { node } {
             set el [ParseInputParamNode $el $in]
         }
     }
-    
+
     set outputNodes [$node getElementsByTagName outputs]
     if {$outputNodes ne ""} {
         foreach out [$outputNodes getElementsByTagName parameter] {
@@ -284,7 +284,7 @@ proc Model::ParseNodalConditionsNode { node } {
     return $el
 }
 
-proc Model::GetElements {args} { 
+proc Model::GetElements {args} {
     variable Elements
     #W "Get elements $args"
     set cumplen [list ]
@@ -295,7 +295,7 @@ proc Model::GetElements {args} {
     return $cumplen
 }
 
-proc Model::getElement {eid} { 
+proc Model::getElement {eid} {
     variable Elements
 
     foreach elem $Elements {
@@ -306,24 +306,24 @@ proc Model::getElement {eid} {
 
 proc Model::GetConstitutiveLawFilters {ename} {
     variable Elements
-    
+
     foreach elem $Elements {
         if {[$elem getName] eq $ename} { return [$elem getConstLawFilters]}
     }
 }
 
-proc Model::GetAvailableConstitutiveLaws {elementId} { 
+proc Model::GetAvailableConstitutiveLaws {elementId} {
     variable ConstitutiveLaws
 
     set cumplen [list ]
-    
+
     set filters [GetConstitutiveLawFilters $elementId]
     #W "filtros $filters"
     foreach cl $ConstitutiveLaws {
         #W "Cumple [$cl getName]? [$cl cumple $filters]"
         if {[$cl cumple $filters]} { lappend cumplen $cl}
     }
-    
+
     return $cumplen
 }
 
@@ -339,7 +339,7 @@ proc Model::GetAllElemOutputs {args} {
 
 proc Model::GetAllElemInputs {} {
     variable Elements
-    
+
     set inputs [dict create]
     foreach el $Elements {
         foreach in [dict keys [$el getInputs]] {
@@ -359,7 +359,7 @@ proc Model::GetNodalConditions {args} {
     #return [Model::getAllNodalConditions]
     variable NodalConditions
     set validlist [list ]
-    
+
     foreach nc $NodalConditions {
         #W "ASK [$nc cumple {*}$args]"
         if {[$nc cumple {*}$args]} {lappend validlist $nc}
@@ -459,6 +459,6 @@ proc Model::CheckNodalConditionOutputState {conditionId outputId {restrictions "
             }
         }
     }
-    
+
     return $ret
 }

--- a/kratos.gid/scripts/Writing/WriteConditions.tcl
+++ b/kratos.gid/scripts/Writing/WriteConditions.tcl
@@ -43,7 +43,7 @@ proc ::write::writeGroupNodeCondition {dictGroupsIterators groupNode condid iter
                 }
             } else {
                 # If kname eq "" => no topology feature match, condition written as nodal
-                if {[$cond hasTopologyFeatures]} {W "$groupid assigned to $condid - Selected invalid entity $ov with $nnodes nodes - Check Conditions.xml"}
+                if {[$cond hasTopologyFeatures]} {error [= "$groupid assigned to $condid - Selected invalid entity $ov with $nnodes nodes - Check Conditions.xml"]}
             }
         } else {
             error "Could not find conditon named $condid"

--- a/kratos.gid/scripts/Writing/Writing.tcl
+++ b/kratos.gid/scripts/Writing/Writing.tcl
@@ -310,9 +310,10 @@ proc write::getEtype {ov group} {
     if {$ov eq "line"} {
         if {$b} {error "Multiple element types in $group over $ov"}
         switch $isquadratic {
-            0 { set ret [list "Linear" 2] }
-            default { set ret [list "Linear" 3] }
+            0 { set ret [list "Line" 2] }
+            default { set ret [list "Line" 3] }
         }
+        set b 1
     }
 
     if {$ov eq "surface"} {


### PR DESCRIPTION
Fixes #886 

Old code was working for linear topologies on conditions because of a trick (string pattern macht instead of string compare)
This was not implemented in elements so it was failing there.

Now all topology searches are by geometry names and number of nodes. p.e: Line 2 -> LineCondition2D2N