### PR TITLE
[Structural] Adding "use_old_stiffness_in_first_iteration" as true by default

### DIFF
--- a/kratos.gid/apps/Structural/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/Structural/write/writeProjectParameters.tcl
@@ -90,6 +90,8 @@ proc ::Structural::write::getOldParametersDict { } {
     dict set solverSettingsDict material_import_settings $materialsDict
 
     # Solution strategy parameters and Solvers
+    # We now added this variable as true by default (in solids is mandatory)
+    dict set solverSettingsDict use_old_stiffness_in_first_iteration true
     set solverSettingsDict [dict merge $solverSettingsDict [write::getSolutionStrategyParametersDict STSolStrat STScheme STStratParams] ]
     set solverSettingsDict [dict merge $solverSettingsDict [write::getSolversParametersDict Structural] ]
 


### PR DESCRIPTION
@RiccardoRossi @rubenzorrilla @loumalouomega 

As we know, in non-linear simulations in solids is mandatory to add always the "`use_old_stiffness_in_first_iteration`"  to be true in the json in order to properly work.

In this PR I am adding this line an setting it to true always. De we agree on this?

Regards