### PR TITLE
[All] Remove deprecated PythonProcess

### DIFF
--- a/kratos.gid/apps/Common/xml/Processes.xml
+++ b/kratos.gid/apps/Common/xml/Processes.xml
@@ -2,12 +2,6 @@
 
 <ProcessList>
 
-	<!--Kratos base process -->
-	<Process n="PythonProcess" pn="Base Python process" python_module="python_process" kratos_module="KratosMultiphysics" help="Python processes empty base class which does nothing">
-		<inputs>
-		</inputs>
-	</Process>
-
 	<!--Processes for nodes -->
 	<Process n="AssignScalarVariableProcess" pn="Assign scalar variable process" python_module="assign_scalar_variable_process" kratos_module="KratosMultiphysics" help="This process fixes the selected components of a given vector variable">
 		<inputs>

--- a/kratos.gid/apps/FSI/xml/Conditions.xml
+++ b/kratos.gid/apps/FSI/xml/Conditions.xml
@@ -23,7 +23,7 @@
   <ConditionItem n="FluidNoSlipInterface2D" pn="FSI fluid interface" ImplementedInFile=".cpp" Interval="False"
 	ImplementedInApplication="FluidApplication" MinimumKratosVersion="9000"
 	WorkingSpaceDimension="2D" LocalSpaceDimension="1" SkinConditions="True" App="Fluid"
-	ElementType="Line" ProcessName="PythonProcess" help="Process to set the interface flag.">
+	ElementType="Line" ProcessName="" help="Auxiliary condition to set the fluid FSI interface.">
     <TopologyFeatures>
       <item  GeometryType="Line" nodes="2" KratosName="WallCondition2D2N"/>
     </TopologyFeatures>
@@ -35,7 +35,7 @@
   <ConditionItem n="StructureInterface2D" pn="FSI structure interface" ImplementedInFile=".cpp" Interval="False"
 	ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000"
 	WorkingSpaceDimension="2D" LocalSpaceDimension="1" SkinConditions="True" App="Structural"
-	ElementType="Line" ProcessName="PythonProcess" help="Process to set the interface flag.">
+	ElementType="Line" ProcessName="Process" help="Auxiliary condition to set the structure FSI interface.">
     <TopologyFeatures>
       <item  GeometryType="Line" nodes="2" KratosName="LineCondition2D2N"/>
     </TopologyFeatures>
@@ -44,7 +44,7 @@
   <ConditionItem n="FluidNoSlipInterface3D" pn="FSI fluid interface" ImplementedInFile=".cpp" Interval="False"
 	ImplementedInApplication="FluidApplication" MinimumKratosVersion="9000"
 	WorkingSpaceDimension="3D" LocalSpaceDimension="1" SkinConditions="True" App="Fluid"
-	ElementType="Surface" ProcessName="PythonProcess" help="Process to set the interface flag.">
+	ElementType="Surface" ProcessName="Process" help="Auxiliary condition to set the fluid FSI interface.">
     <TopologyFeatures>
       <item  GeometryType="Triangle" nodes="3" KratosName="WallCondition3D3N"/>
       <item  GeometryType="Quadrilateral" nodes="4" KratosName="WallCondition3D4N"/>
@@ -57,7 +57,7 @@
   <ConditionItem n="StructureInterface3D" pn="FSI structure interface" ImplementedInFile=".cpp" Interval="False"
 	ImplementedInApplication="StructuralMechanicsApplication" MinimumKratosVersion="9000"
 	WorkingSpaceDimension="3D" LocalSpaceDimension="1" SkinConditions="True" App="Structural"
-	ElementType="Surface" ProcessName="PythonProcess" help="Process to set the interface flag.">
+	ElementType="Surface" ProcessName="Process" help="Auxiliary condition to set the structure FSI interface.">
     <TopologyFeatures>
       <item  GeometryType="Triangle" nodes="3" KratosName="SurfaceCondition3D3N"/>
       <item  GeometryType="Quadrilateral" nodes="4" KratosName="SurfaceCondition3D4N"/>


### PR DESCRIPTION
Following [this](https://github.com/KratosMultiphysics/Kratos/pull/8039) in the main repository, this PR removes the deprecated `PythonProcess`.