### PR TITLE
[MPM] Information about background_grid deleted in ParticleMaterials.json

### DIFF
--- a/kratos.gid/apps/MPM/write/write.tcl
+++ b/kratos.gid/apps/MPM/write/write.tcl
@@ -171,11 +171,13 @@ proc MPM::write::writeCustomFilesEvent { } {
     set new_mats [list ]
     foreach mat $mats_json {
         set type [dict exists $mat Material constitutive_law]
-        if {$type eq 0} {
-            set submodelpart [lindex [split [dict get $mat model_part_name] "."] end]
-            dict set mat model_part_name Background_Grid.$submodelpart
+#         if {$type eq 0} {
+#             set submodelpart [lindex [split [dict get $mat model_part_name] "."] end]
+#             dict set mat model_part_name Background_Grid.$submodelpart
+#         }
+        if {$type eq 1} {
+            lappend new_mats $mat
         }
-        lappend new_mats $mat
     }
     write::OpenFile [GetAttribute materials_file]
     write::WriteJSON [dict create properties $new_mats]

--- a/kratos.gid/apps/MPM/xml/Elements.xml
+++ b/kratos.gid/apps/MPM/xml/Elements.xml
@@ -40,7 +40,7 @@
     </TopologyFeatures>
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
-      <filter field="App" value="MPM"/> 
+      <filter field="App" value="MPM"/>
       <filter field="FormulationType" value="Mixed"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
@@ -71,7 +71,7 @@
     </TopologyFeatures>
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
-      <filter field="App" value="MPM"/> 
+      <filter field="App" value="MPM"/>
       <filter field="FormulationType" value="Irreducible"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
@@ -94,7 +94,7 @@
     </outputs>
   </ElementItem>
 
-  <ElementItem n="UpdatedLagrangian3D" pn="Updated lagrangian" ov="volume" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="ParticleMechanicsApplication" MinimumKratosVersion="9000"  WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Solid" help="Updated Lagrangian 3D element for large deformation kinematics consists of a material point and connectivity nodes." AnalysisType="non_linear">
+  <ElementItem n="UpdatedLagrangian3D" pn="Updated lagrangian" ov="volume" ImplementedInFile="updated_lagrangian.cpp" ImplementedInApplication="ParticleMechanicsApplication" MinimumKratosVersion="9000"  WorkingSpaceDimension="3D" LocalSpaceDimension="3" RequiresLocalAxes="False" LargeDeformation="False" ElementType="Material_domain" help="Updated Lagrangian 3D element for large deformation kinematics consists of a material point and connectivity nodes." AnalysisType="non_linear">
     <!--here we could add a list of all of the possible geometries-->
     <TopologyFeatures>
       <item GeometryType="Tetrahedra" nodes="4" KratosName="UpdatedLagrangian3D4N"/>
@@ -102,7 +102,7 @@
     </TopologyFeatures>
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
-      <filter field="App" value="MPM"/> 
+      <filter field="App" value="MPM"/>
       <filter field="FormulationType" value="Irreducible"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->
@@ -131,7 +131,7 @@
     </TopologyFeatures>
     <!-- here we add the block of features which we require from the constitutive law-->
     <ConstitutiveLaw_FilterFeatures>
-      <filter field="App" value="MPM"/> 
+      <filter field="App" value="MPM"/>
       <filter field="FormulationType" value="Mixed"/>
     </ConstitutiveLaw_FilterFeatures>
     <!--define list of NodalConditions-->


### PR DESCRIPTION
**📝 Description**
Information about the Background grid has been deleted in the ParticleMaterials.json: 

![Before_mod](https://user-images.githubusercontent.com/92164618/202509224-8bfdf60a-ab7f-4212-bc40-5fba4ea8bd17.png)