### PR TITLE
Add use_block_builder to false in eigen analysis

### DIFF
--- a/kratos.gid/apps/Structural/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/Structural/write/writeProjectParameters.tcl
@@ -169,6 +169,7 @@ proc ::Structural::write::getOldParametersDict { {stage ""} } {
     if {$solutiontype eq "eigen_value"} {
         dict unset projectParametersDict output_processes
         dict unset projectParametersDict solver_settings analysis_type
+        dict set projectParametersDict solver_settings builder_and_solver_settings use_block_builder false
     }
 
     return $projectParametersDict


### PR DESCRIPTION
Fixes #946 

Adds
```
builder_and_solver_settings" : {
 "use_block_builder" : false
}
```

to the Project parameters > solver settings if eigen analysis is selected

No chance for the user to change it in the GUI