### PR TITLE
MDPA Import Geometries & quadratic mesh

### DIFF
--- a/kratos.gid/scripts/Controllers/MdpaImportMesh.tcl
+++ b/kratos.gid/scripts/Controllers/MdpaImportMesh.tcl
@@ -241,13 +241,14 @@ proc Kratos::GuessElementTypeFromMDPA {line} {
         set detected_mesh_quad [Kratos::GuessQuadMesh $element_name $dim $nnodes]
         set is_quadratic [GiD_Set Model(QuadraticType)]
         if { $detected_mesh_quad eq "0" } {
-            if {$is_quadratic ne "0"} {W "We have changed the mesh mode to linear. Check preferences to change it back."}
+            if {$is_quadratic ne "0"} {W "We have changed the mesh mode to linear. Check Mesh menu to change it back."}
             GiD_Set Model(QuadraticType) 0
-        } elseif {$is_quadratic eq "1"} {
-            if {is_quadratic ne "1"} {W "We have changed the mesh mode to quadratic. Check preferences to change it back."}
+        } 
+        if {$detected_mesh_quad eq "1"} {
+            if {$is_quadratic ne "1"} {W "We have changed the mesh mode to quadratic. Check Mesh menu to change it back."}
             GiD_Set Model(QuadraticType) 1
         }
-
+        
         switch $nnodes {
             2 {
                 set element_type "Line"
@@ -314,16 +315,20 @@ proc Kratos::GuessElementTypeFromMDPA {line} {
 }
 
 proc Kratos::GuessQuadMesh {element_name dim nnodes} {
-    set guess -1
-    # If element name contains "Line"
-    if {[string first "Line" $element_name] != -1} {
-        if {$nnodes eq 2} {
-            set guess 0
-        } elseif {$nnodes eq 3} {
-            set guess 1
-        }
-    }
-    return $guess
+    if {$nnodes eq 6 && $dim eq 2} {return 1}
+    if {$nnodes eq 4 && $dim eq 2} {return 0}
+    if {$nnodes eq 4 && $dim eq 3} {return 0}
+    if {$nnodes eq 8 && $dim eq 2} {return 1}
+    if {$nnodes eq 8 && $dim eq 3} {return 0}
+    if {$nnodes eq 2 }  {return 0}
+    if {$nnodes eq 9 }  {return 2}
+    if {$nnodes eq 20 } {return 1}
+    if {$nnodes eq 27 } {return 2}
+    if {$nnodes eq 15 } {return 1}
+    if {$nnodes eq 18 } {return 2}
+    if {$nnodes eq 5 }  {return 0}
+    if {$nnodes eq 13 } {return 1}
+    return -1
 }
 
 #register the proc to be automatically called when dropping a file

--- a/kratos.gid/scripts/Controllers/MdpaImportMesh.tcl
+++ b/kratos.gid/scripts/Controllers/MdpaImportMesh.tcl
@@ -188,6 +188,9 @@ proc Kratos::GuessElementTypeFromMDPA {line} {
     set element_type "unknown"
     set element_name [lindex $line 2]
     set element_name [lindex [split $element_name "//"] 0]
+
+    # 0: linear, 1: quadratic, 2: biquadratic
+    set is_quadratic [write::isquadratic]
     
     if {$element_name eq "Sphere3D"} {
         set element_type "Sphere"
@@ -196,6 +199,7 @@ proc Kratos::GuessElementTypeFromMDPA {line} {
     } elseif {$element_name in {"CylinderContinuumParticle2D" "CylinderParticle2D"}} {
         set element_type "Circle"
     } else {
+
         set dim [string index $element_name end-3]
         set nnodes [string index $element_name end-1]
         switch $nnodes {
@@ -203,7 +207,11 @@ proc Kratos::GuessElementTypeFromMDPA {line} {
                 set element_type "Line"
             }
             3 {
-                set element_type "Triangle"
+                if {$is_quadratic eq "0"} {
+                    set element_type "Triangle"
+                } else {
+                    set element_type "Line"
+                }
             }
             4 {
                 if {$dim eq 2} {
@@ -216,10 +224,14 @@ proc Kratos::GuessElementTypeFromMDPA {line} {
                 set element_type "Pyramid"
             }
             6 { 
-                if {$dim eq 2} {
-                    set element_type "Triangle"
+                if {$is_quadratic eq "0"} {
+                    if {$dim eq 2} {
+                        set element_type "Triangle"
+                    } 
                 } else {
-                    set element_type "Prism"
+                    if {$dim eq 2} {
+                        set element_type "Triangle"
+                    } 
                 }
             }
             8 { 


### PR DESCRIPTION
Import MDPA feature did not import quadratic lines properly
ALSO import MDPA with geometries

Only quadratic lines and linear triangles were having problems, since they are both 2D and 3 nodes.

The rest of entities with the same nodes can be determined by the dimension:
4 noded linear quadrilateral and tetrahedra (2D <-> 3D)
6 noded quadratic triangles and linear prism (2D <-> 3D)
8 noded quadratic quadrilateral and linear hexaedra (2D <-> 3D)

The rest do not share number of connectivities



https://gidsimulation.atlassian.net/wiki/spaces/GRM/pages/2385547733/Element+type