### PR TITLE
App mesh type

### DIFF
--- a/kratos.gid/apps/GeoMechanics/app.json
+++ b/kratos.gid/apps/GeoMechanics/app.json
@@ -24,7 +24,8 @@
     "start_script": "::GeoMechanics::Init",
     "requirements": {
         "apps": ["Structural"],
-        "minimum_gid_version": "16.1.4d"
+        "minimum_gid_version": "16.1.4d",
+        "mesh_type": "quadratic"
     },
     "permissions": {
         "open_tree": true,

--- a/kratos.gid/scripts/Applications.tcl
+++ b/kratos.gid/scripts/Applications.tcl
@@ -333,6 +333,20 @@ proc apps::ActivateApp_do {app} {
         set app_minimum_gid_version [dict get [$app getProperty requirements] minimum_gid_version]
         if {[GiDVersionCmp $app_minimum_gid_version] < 0} {W "Caution. Minimum GiD version is $app_minimum_gid_version"}
     }
+    
+    # If mesh_type is not defined, do not touch it
+    if {[dict exists [$app getProperty requirements] mesh_type]} {
+        set mesh_type [dict get [$app getProperty requirements] mesh_type]
+        # If its quadratic, warn user and set it
+        if {$mesh_type eq "quadratic"} {
+            GiD_Set Model(QuadraticType) 1
+            ::GidUtils::SetWarnLine "Setting mesh mode: $mesh_type"
+        } else {
+            # If it's set to anything else, set it to linear
+            GiD_Set Model(QuadraticType) 0
+            ::GidUtils::SetWarnLine "Setting mesh mode: linear"
+        }
+    }
     if {[write::isBooleanTrue [$app getPermission import_files]]} { Kratos::LoadImportFiles }
     if {[write::isBooleanTrue [$app getPermission wizard]]} { Kratos::LoadWizardFiles }
     if {[$app getProperty start_script] ne ""} {eval [$app getProperty start_script] $app}


### PR DESCRIPTION
In app.json, the application can now define the default mesh type for it's models.
By default, it's not modified.
If the app sets it to 'quadratic' it will be set in the Start event, so the user can change it later.
If the app sets it to anything else, it will be set as linear

Just for testing, geomechanics sets it to quadratic