### PR TITLE
FixedDisplacement group fixed in MPM examples

### DIFF
--- a/kratos.gid/apps/MPM/examples/CantileverBeam.tcl
+++ b/kratos.gid/apps/MPM/examples/CantileverBeam.tcl
@@ -138,11 +138,6 @@ proc ::MPM::examples::CantileverBeam::TreeAssignation2D {args} {
     spdAux::SetValuesOnBaseNode $mpm_grid_part $props
 
     # Fix Displacement
-    ## Create interval subgroup
-    GiD_Groups clone FixedDisplacement Total
-    GiD_Groups edit parent Total FixedDisplacement
-    spdAux::AddIntervalGroup FixedDisplacement "FixedDisplacement"
-    GiD_Groups edit state "FixedDisplacement" hidden
 
     ## Assign boundary condition
     set mpm_bc_route [spdAux::getRoute "MPMNodalConditions"]

--- a/kratos.gid/apps/MPM/examples/GranularFlow.tcl
+++ b/kratos.gid/apps/MPM/examples/GranularFlow.tcl
@@ -137,12 +137,6 @@ proc ::MPM::examples::GranularFlow::TreeAssignation2D {args} {
     set props [list Element GRID$nd ]
     spdAux::SetValuesOnBaseNode $mpm_grid_part $props
 
-    # Fix Displacement
-    ## Create interval subgroup
-    GiD_Groups clone FixedDisplacement Total
-    GiD_Groups edit parent Total FixedDisplacement
-    spdAux::AddIntervalGroup FixedDisplacement "FixedDisplacement"
-    GiD_Groups edit state "FixedDisplacement" hidden
 
     ## Assign boundary condition
     set mpm_bc_route [spdAux::getRoute "MPMNodalConditions"]

--- a/kratos.gid/apps/MPM/examples/StaticCantileverBeam.tcl
+++ b/kratos.gid/apps/MPM/examples/StaticCantileverBeam.tcl
@@ -142,15 +142,6 @@ proc ::MPM::examples::StaticCantileverBeam::TreeAssignation2D {args} {
     set props [list Element GRID$nd ]
     spdAux::SetValuesOnBaseNode $mpm_grid_part $props
 
-    # Fix Displacement
-    ## Create interval subgroup
-    GiD_Groups clone FixedDisplacement Total
-    GiD_Groups edit parent Total FixedDisplacement
-    spdAux::AddIntervalGroup FixedDisplacement "FixedDisplacement"
-    GiD_Groups edit state "FixedDisplacement" hidden
-
-    #Slip condition
-
     ## Assign boundary condition
     set mpm_bc_route [spdAux::getRoute "MPMNodalConditions"]
     set mpm_displacement_route "${mpm_bc_route}/condition\[@n='DISPLACEMENT'\]"


### PR DESCRIPTION
Fixed the FixedDisplacement group in MPM examples.

This boundary condition didn't appear as a "group" in the GiD pannel interface. 
![FixedDisplacement](https://github.com/KratosMultiphysics/GiDInterface/assets/92164618/575d6447-f289-4b4f-b6dd-2abc59aeb958)
