### PR TITLE
New line geom mesh relation

### DIFF
--- a/kratos.gid/apps/Stent/start.tcl
+++ b/kratos.gid/apps/Stent/start.tcl
@@ -49,5 +49,5 @@ proc ::Stent::CustomToolbarItems { } {
 }
 
 proc ::Stent::BeforeMeshGeneration { size } { 
-    ::Structural::BeforeMeshGeneration $size
+    catch {::Structural::BeforeMeshGeneration $size}
 }

--- a/kratos.gid/apps/Structural/start.tcl
+++ b/kratos.gid/apps/Structural/start.tcl
@@ -22,16 +22,6 @@ proc ::Structural::Init { app } {
     ::Structural::write::Init
 }
 
-# Create the old-gid condition relation_line_geo_mesh to link geometry and mesh entities.
-# Topic: Local axes, beams
-# TODO: remove this when GiD creates this relation automatically
-proc ::Structural::BeforeMeshGeneration { size } {
-    GiD_UnAssignData condition relation_line_geo_mesh Lines all
-    foreach group [GiD_Groups list] {
-        GiD_AssignData condition relation_line_geo_mesh Lines {0} [GiD_EntitiesGroups get $group lines]
-    }
-}
-
 # Some conditions applied over small displacement parts must change the topology name... una chufa
 proc ::Structural::ApplicationSpecificGetCondition {condition group etype nnodes} {
     return [Structural::write::ApplicationSpecificGetCondition $condition $group $etype $nnodes]

--- a/kratos.gid/apps/Structural/write/write.tcl
+++ b/kratos.gid/apps/Structural/write/write.tcl
@@ -292,9 +292,18 @@ proc ::Structural::write::writeHinges { } {
             foreach geom_line [GiD_EntitiesGroups get $group lines] {
                 # ask the mesh for the linear elements of this line
                 # check https://gidsimulation.atlassian.net/wiki/spaces/GCM/pages/2385543949/Geometry
-                set linear_elements [lindex [GiD_Geometry get line $geom_line mesh] 4]
-                set first [::tcl::mathfunc::min {*}$linear_elements]
-                set end [::tcl::mathfunc::max {*}$linear_elements]
+                # set linear_elements [lindex [GiD_Geometry get line $geom_line mesh] 4]
+                # set first [::tcl::mathfunc::min {*}$linear_elements]
+                # set end [::tcl::mathfunc::max {*}$linear_elements]
+
+                lassign [lrange [GiD_Geometry line $geom_line] 2 3] first_point end_point
+                set first [GiD_Geometry get point $first_point node] 
+                set end [GiD_Geometry get point $end_point node]
+                if {$first eq "" || $end eq ""} {
+                    W "Error: Line $geom_line has no nodes. Please make sure the mesh is attached to the geometry."
+                    continue
+                }
+
                 if {[llength $first_list] > 0} {
                     set value [join $first_list ,]
                     write::WriteString [format "$id_f \[%d\] (%s)" $first [llength $first_list] $value]

--- a/kratos.gid/apps/Structural/write/write.tcl
+++ b/kratos.gid/apps/Structural/write/write.tcl
@@ -296,7 +296,7 @@ proc ::Structural::write::writeHinges { } {
                 # set first [::tcl::mathfunc::min {*}$linear_elements]
                 # set end [::tcl::mathfunc::max {*}$linear_elements]
 
-                lassign [lrange [GiD_Geometry line $geom_line] 2 3] first_point end_point
+                lassign [lrange [GiD_Geometry get line $geom_line] 2 3] first_point end_point
                 set first [GiD_Geometry get point $first_point node] 
                 set end [GiD_Geometry get point $end_point node]
                 if {$first eq "" || $end eq ""} {

--- a/kratos.gid/apps/Structural/write/write.tcl
+++ b/kratos.gid/apps/Structural/write/write.tcl
@@ -249,13 +249,6 @@ proc ::Structural::write::writeHinges { } {
     # format for writing ids
     set id_f [dict get $write::formats_dict ID]
 
-    # Preprocess old_conditions. Each mesh linear element remembers the origin line in geometry
-    set match_dict [dict create]
-    foreach line [GiD_Info conditions relation_line_geo_mesh mesh] {
-        lassign $line E eid - geom_line
-        dict lappend match_dict $geom_line $eid
-    }
-
     # Process groups assigned to Hinges
     if {$::Model::SpatialDimension eq "3D"} {
         set xp1 "[spdAux::getRoute [GetAttribute nodal_conditions_un]]/condition\[@n = 'CONDENSED_DOF_LIST'\]/group"
@@ -297,7 +290,9 @@ proc ::Structural::write::writeHinges { } {
 
             # Write Left and Rigth end of each geometrical bar
             foreach geom_line [GiD_EntitiesGroups get $group lines] {
-                set linear_elements [dict get $match_dict $geom_line]
+                # ask the mesh for the linear elements of this line
+                # check https://gidsimulation.atlassian.net/wiki/spaces/GCM/pages/2385543949/Geometry
+                set linear_elements [lindex [GiD_Geometry get line $geom_line mesh] 4]
                 set first [::tcl::mathfunc::min {*}$linear_elements]
                 set end [::tcl::mathfunc::max {*}$linear_elements]
                 if {[llength $first_list] > 0} {

--- a/kratos.gid/kratos.cnd
+++ b/kratos.gid/kratos.cnd
@@ -29,11 +29,5 @@ CANREPEAT: yes
 QUESTION: pair_name
 VALUE: -
 END CONDITION
-CONDITION: relation_line_geo_mesh
-CONDTYPE: over lines
-CONDMESHTYPE: over body elements
-CANREPEAT: no
-QUESTION: id#FUNC#(NumEntity)
-VALUE: 0
-END CONDITION
+
 


### PR DESCRIPTION
This PR will remove an annoying warning when using lines in Structural mechanics app

The feature may affect  Structural > Beams > Hinges.

Until this PR we were getting the mdpa data:

```
Begin ElementalData CONDENSED_DOF_LIST // Group: Hinge Auto1
   25 [3] (0,1,2)
   38 [3] (3,4,5)
End ElementalData
```
Being 25 and 38 the starting node and final node of the line with boundary condition > Hinge

The way we used to pick this numbers was:
 - Get the list of nodes of the line
 - Sort them numerically (not following the line normal, just sort the ids)
 - Get min and max
 
This works fine since GiD meshes this way **but**:
- Mesh could be renumbered
- This does not preserve the direction of the geometrical line.
- To get the relation between the geometrical line and the nodes, we were using an old gid feature called condition over body, wich caused annoying messages when fails

## News
With this PR :
![image](https://github.com/KratosMultiphysics/GiDInterface/assets/5918085/f45a66c7-e14c-4da1-940a-d2f8d6fdafc2)

- We'll keep the line direction. You can see it in the image, there is a pink arrow showing the normal, and a blue arrow showing the direction.
- We get rid of this old gid feature, and start using the new feature: GiD Meshes and Geometries are attached, so we can navigate from a geometry line to it's mesh line elements, and viceversa.
- No more annoying messages.
- No need to increment the Minimum GiD version, this should work with 16.1.4d

The output will be:


```
Begin ElementalData CONDENSED_DOF_LIST // Group: Hinge Auto1
   38 [3] (0,1,2)
   25 [3] (3,4,5)
End ElementalData
```
Wich is fine, following the line direction, the first node is 38, and the last is 25.

@KratosMultiphysics/structural-mechanics 

@AlejandroCornejo by petition of @RiccardoRossi 
