### PR TITLE
[Dam] Add initial joint width to joints and fix problem with tables

### DIFF
--- a/kratos.gid/apps/Dam/examples/ThermoMechaDam2D.tcl
+++ b/kratos.gid/apps/Dam/examples/ThermoMechaDam2D.tcl
@@ -164,7 +164,7 @@ proc ::Dam::examples::ThermoMechaDam2D::TreeAssignation {args} {
         # Bofang Temperature
         set bofang_temperature "$damDirichletConditions/condition\[@n='BOFANGTEMPERATURE'\]"
         set bofang_temperature_node [customlib::AddConditionGroupOnXPath $bofang_temperature Water]
-        set props_bofang_temperature [list is_fixed 1 Gravity_Direction Y Reservoir_Bottom_Coordinate_in_Gravity_Direction 0.0 Surface_Temp 15.19 Bottom_Temp 9.35 Height_Dam 30.0 Temperature_Amplitude 6.51 Day_Ambient_Temp 201 Water_level 20.0 Month 7 ]
+        set props_bofang_temperature [list is_fixed 1 Gravity_Direction Y Reservoir_Bottom_Coordinate_in_Gravity_Direction 0.0 Surface_Temp 15.19 Bottom_Temp 9.35 Height_Dam 30.0 Temperature_Amplitude 6.51 Day_Max_Temp 201 Water_level 20.0 Month 7 ]
         spdAux::SetValuesOnBaseNode $bofang_temperature_node $props_bofang_temperature
 
         # Uniform Temperature

--- a/kratos.gid/apps/Dam/write/write.tcl
+++ b/kratos.gid/apps/Dam/write/write.tcl
@@ -70,25 +70,25 @@ proc ::Dam::write::UpdateMaterials { } {
         # Modify constitutive law
         set newconstlaw $constlaw
         if {$constlaw eq "ElasticCohesive3DLaw"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
         }
         if {$constlaw eq "ElasticCohesive2DPlaneStrain"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "ElasticCohesive2DLaw"
         }
         if {$constlaw eq "ElasticCohesive2DPlaneStress"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "ElasticCohesive2DLaw"
         }
         if {$constlaw eq "IsotropicDamageCohesive2DPlaneStress"}  {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "IsotropicDamageCohesive2DLaw"
         }
         if {$constlaw eq "IsotropicDamageCohesive2DPlaneStrain"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "IsotropicDamageCohesive2DLaw"
         }

--- a/kratos.gid/apps/Dam/write/write.tcl
+++ b/kratos.gid/apps/Dam/write/write.tcl
@@ -70,25 +70,25 @@ proc ::Dam::write::UpdateMaterials { } {
         # Modificar la ley constitutiva
         set newconstlaw $constlaw
         if {$constlaw eq "ElasticCohesive3DLaw"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
         }
         if {$constlaw eq "ElasticCohesive2DPlaneStrain"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "ElasticCohesive2DLaw"
         }
         if {$constlaw eq "ElasticCohesive2DPlaneStress"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "ElasticCohesive2DLaw"
         }
         if {$constlaw eq "IsotropicDamageCohesive2DPlaneStress"}  {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "IsotropicDamageCohesive2DLaw"
         }
         if {$constlaw eq "IsotropicDamageCohesive2DPlaneStrain"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "IsotropicDamageCohesive2DLaw"
         }

--- a/kratos.gid/apps/Dam/write/write.tcl
+++ b/kratos.gid/apps/Dam/write/write.tcl
@@ -69,19 +69,26 @@ proc ::Dam::write::UpdateMaterials { } {
         set constlaw [dict get $props ConstitutiveLaw]
         # Modificar la ley constitutiva
         set newconstlaw $constlaw
+        if {$constlaw eq "ElasticCohesive3DLaw"} {
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
+        }
         if {$constlaw eq "ElasticCohesive2DPlaneStrain"} {
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "ElasticCohesive2DLaw"
         }
         if {$constlaw eq "ElasticCohesive2DPlaneStress"} {
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "ElasticCohesive2DLaw"
         }
         if {$constlaw eq "IsotropicDamageCohesive2DPlaneStress"}  {
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "IsotropicDamageCohesive2DLaw"
         }
         if {$constlaw eq "IsotropicDamageCohesive2DPlaneStrain"} {
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "IsotropicDamageCohesive2DLaw"
         }

--- a/kratos.gid/apps/Dam/write/write.tcl
+++ b/kratos.gid/apps/Dam/write/write.tcl
@@ -70,25 +70,25 @@ proc ::Dam::write::UpdateMaterials { } {
         # Modify constitutive law
         set newconstlaw $constlaw
         if {$constlaw eq "ElasticCohesive3DLaw"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
         }
         if {$constlaw eq "ElasticCohesive2DPlaneStrain"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "ElasticCohesive2DLaw"
         }
         if {$constlaw eq "ElasticCohesive2DPlaneStress"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "ElasticCohesive2DLaw"
         }
         if {$constlaw eq "IsotropicDamageCohesive2DPlaneStress"}  {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "IsotropicDamageCohesive2DLaw"
         }
         if {$constlaw eq "IsotropicDamageCohesive2DPlaneStrain"} {
-            dict set matdict $mat INITIAL_JOINT_WIDTH  0.0
+            dict set matdict $mat INITIAL_JOINT_WIDTH  1.0e-3
             dict set matdict $mat THICKNESS  1.0
             set newconstlaw "IsotropicDamageCohesive2DLaw"
         }

--- a/kratos.gid/apps/Dam/write/write.tcl
+++ b/kratos.gid/apps/Dam/write/write.tcl
@@ -221,6 +221,7 @@ proc ::Dam::write::writeTables { } {
     set printed_tables [list ]
     foreach table [GetPrinTables] {
         lassign $table tableid fileid condid groupid valueid
+        set groupid [write::GetWriteGroupName $groupid]
         dict set TableDict $condid $groupid $valueid tableid $tableid
         dict set TableDict $condid $groupid $valueid fileid $fileid
         if {$tableid ni $printed_tables} {

--- a/kratos.gid/apps/Dam/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/Dam/write/writeProjectParameters.tcl
@@ -376,7 +376,7 @@ proc ::Dam::write::DefinitionDomains { } {
 # This process assign a number for the different tables instead of names (this is for matching with .mdpa)
 proc ::Dam::write::ChangeFileNameforTableid { processList } {
 
-    # Variable global definida al principio y utilizada para transferir entre procesos el número de tablas existentes
+    # Global variable defined at the beginning and used to transfer between processes the number of existing tables
     variable number_tables
 
     set returnList [list ]
@@ -862,12 +862,12 @@ proc ::Dam::write::DevicesOutput { } {
 
 proc ::Dam::write::TemperaturebyDevices { } {
 
-    # Variable global definida al principio y utilizada para transferir entre procesos el número de tablas existentes
+    # Global variable defined at the beginning and used to transfer between processes the number of existing tables
     variable number_tables
 
     set device_temp_state [write::getValue DamTemperatureState]
     set lista [list ]
-    set listaFiles [list ]
+    set files_list [list ]
 
     if { $device_temp_state == True} {
 
@@ -919,13 +919,13 @@ proc ::Dam::write::TemperaturebyDevices { } {
             dict set parameterDict value $value
 
             if {$fileid ni [list "" "- No file" $::spdAux::no_file_string]} {
-                if {$fileid ni $listaFiles} {
-                    lappend listaFiles $fileid
+                if {$fileid ni $files_list} {
+                    lappend files_list $fileid
                     incr number_devices
                     dict set parameterDict table [expr $number_tables + $number_devices]
                 } else {
-                    for {set i 0} {$i < [llength $listaFiles]} {incr i} {
-                        if {$fileid eq [lindex $listaFiles $i]} {
+                    for {set i 0} {$i < [llength $files_list]} {incr i} {
+                        if {$fileid eq [lindex $files_list $i]} {
                             dict set parameterDict table [expr $number_tables + $i + 1]
                             break
                         }

--- a/kratos.gid/apps/Dam/xml/Processes.xml
+++ b/kratos.gid/apps/Dam/xml/Processes.xml
@@ -43,7 +43,7 @@
         <parameter n="Bottom_Temp" pn="Bottom Temperature" type="double" v="0.0"/>
         <parameter n="Height_Dam" pn="Height Dam" type="double" v="0.0"/>
         <parameter n="Temperature_Amplitude" pn="Temperature Amplitude" type="double" v="0.0"/>
-        <parameter n="Day_Ambient_Temp" pn="Day" type="integer" v="0.0"/>
+        <parameter n="Day_Max_Temp" pn="Day Maximum Temperature" type="integer" v="0.0"/>
         <parameter n="Water_level" pn="Water Level" type="double" v="0.0"/>
         <parameter n="Water_level_Table" pn="Water Level table filename" type="tablefile" v=""/>
         <parameter n="Month" pn="Month" type="double" v="0.0"/>


### PR DESCRIPTION
- Add INITIAL_JOINT_WIDTH as default to joint properties.
- Change some variable names and improve some comments.
- Fix TableId initialization as groupid variable was not written properly, now: set groupid [write::GetWriteGroupName $groupid]

This PR fixes issue #981.