### PR TITLE
Free surface writes geometries

### DIFF
--- a/kratos.gid/apps/FreeSurface/app.json
+++ b/kratos.gid/apps/FreeSurface/app.json
@@ -38,7 +38,7 @@
         "properties_location": "json",
         "model_part_name": "FluidModelPart",
         "output_model_part_name": "",
-        "write_mdpa_mode": "entities"
+        "write_mdpa_mode": "geometries"
     },
     "main_launch_file": "../../exec/MainKratos.py"
 }

--- a/kratos.gid/apps/FreeSurface/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/FreeSurface/write/writeProjectParameters.tcl
@@ -23,6 +23,8 @@ proc ::FreeSurface::write::getParametersDict { } {
     # # processes
     dict set projectParametersDict processes [::Fluid::write::GetProcesses_Dict]
 
+    set projectParametersDict [::write::GetModelersDict $projectParametersDict]
+
     return $projectParametersDict
 }
 

--- a/kratos.gid/scripts/Writing/WriteProjectParameters.tcl
+++ b/kratos.gid/scripts/Writing/WriteProjectParameters.tcl
@@ -663,8 +663,10 @@ proc write::GetMatchSubModelPart { what {stage ""} } {
         set group_name [$group @n]
         
         set group_name [write::GetWriteGroupName $group_name]
-        if {$group_name ni $processed_groups_list} {lappend processed_groups_list $group_name} {continue}
-        if {$what == "condition"} {set cid [[$group parent] @n]} {
+        #if {$group_name ni $processed_groups_list} {lappend processed_groups_list $group_name} {continue}
+        if {$what == "condition"} {
+            set cid [[$group parent] @n]
+        } else {
             set element_node [$group selectNodes "./value\[@n='Element']"]
             if {[llength $element_node] == 0} {continue}
             set cid [write::getValueByNode $element_node]
@@ -672,6 +674,8 @@ proc write::GetMatchSubModelPart { what {stage ""} } {
         if {$cid eq ""} {continue}
         if {$what == "condition"} {set entity [::Model::getCondition $cid]} {set entity [::Model::getElement $cid]}
         if {$entity eq ""} {continue}
+        
+        if {$group_name ni $processed_groups_list} {lappend processed_groups_list $group_name} {continue}
         if {$what == "condition"} {
             if {[$entity getGroupBy] eq "Condition"} {
                 set good_name "_HIDDEN_$cid"


### PR DESCRIPTION
Free surface fails running because of this:

In the first picture we can see the the group Fluid:
![image](https://github.com/user-attachments/assets/aebc362d-48d9-4033-82bd-44b3bd556e02)

In the second picture we can see the group Surface bottom:
![image](https://github.com/user-attachments/assets/29ad562d-ed90-4788-af29-372648bca4e7)

They do share elements

In the MDPA, both groups are written as `Begin Geometries Triangle2D3`
So there are elements declared 2 times, with the same id and the same connectivities. This should not be a problem, but it is.

You can see the log:

```

  File "C:\Users\garat\Desktop\Deploy_Kratos\Deploy_Kratos\KratosMultiphysics\analysis_stage.py", line 80, in Initialize
    self._ModelersSetupModelPart()
  File "C:\Users\garat\Desktop\Deploy_Kratos\Deploy_Kratos\KratosMultiphysics\analysis_stage.py", line 285, in _ModelersSetupModelPart
    modeler.SetupModelPart()
  File "C:\Users\garat\Desktop\Deploy_Kratos\Deploy_Kratos\KratosMultiphysics\modelers\import_mdpa_modeler.py", line 36, in SetupModelPart
    KratosMultiphysics.SingleImportModelPart.Import(
RuntimeError: Error: Attempting to add a new geometry with Id :892, unfortunately a (different) element with the same Id already exists




in kratos/includes/model_part.h:1538: ModelPart::AddGeometries
   kratos/includes/model_part.h:1560: ModelPart::AddGeometries
   kratos/sources/model_part_io.cpp:1771: ModelPartIO::ReadGeometriesBlock
   kratos/sources/model_part_io.cpp:618: ModelPartIO::ReadModelPart


```

Then in the submodelparts definition, each group references it's triangles.

