### PR TITLE
[MPM] output energy option

### DIFF
--- a/kratos.gid/apps/MPM/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/MPM/write/writeProjectParameters.tcl
@@ -257,7 +257,12 @@ proc ::MPM::write::GetOutputProcessesList { } {
         dict set energy_parameters_dict print_format [write::getValue EnergyOptions PrintFormat]
 
         set output_file_settings_dict [dict create ]
-        dict set output_file_settings_dict output_path [write::getValue OutputFileSettings OutputPath]
+        set output_path_value [write::getValue OutputFileSettings OutputPath]
+        # If OutputPath is empty, use "." (current folder), otherwise use the provided value
+        if {$output_path_value eq ""} {
+            set output_path_value "."
+        }
+        dict set output_file_settings_dict output_path [string map {} $output_path_value]
         dict set output_file_settings_dict file_name [write::getValue OutputFileSettings FileName]
         dict set output_file_settings_dict file_extension [write::getValue OutputFileSettings FileExtension]
         dict set energy_parameters_dict output_file_settings $output_file_settings_dict
@@ -321,3 +326,6 @@ proc ::MPM::write::getModelersParametersList { old_modelers } {
 proc ::MPM::write::writeParametersEvent { } {
     write::WriteJSON [getParametersDict]
 }
+
+
+

--- a/kratos.gid/apps/MPM/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/MPM/write/writeProjectParameters.tcl
@@ -236,6 +236,36 @@ proc ::MPM::write::GetOutputProcessesList { } {
         dict set output_process save_restart_process [list $restart_dict]
 
     }
+    
+    # Energy output
+    lassign [write::getValue EnergyOutput EnableEnergyOutput] energy_output
+    if {$energy_output eq "Yes"} {
+        set energy_dict [dict create ]
+        dict set energy_dict python_module mpm_write_energy_output_process
+        dict set energy_dict kratos_module "KratosMultiphysics.MPMApplication"
+        dict set energy_dict process_name MPMWriteEnergyOutputProcess
+
+        set energy_parameters_dict [dict create ]
+        dict set energy_parameters_dict model_part_name "MPM_Material"
+        set energy_output_control [write::getValue EnergyOptions OutputControlType]
+        dict set energy_parameters_dict output_control_type $energy_output_control
+        if {$energy_output_control eq "time"} {
+            dict set energy_parameters_dict output_interval [write::getValue EnergyOptions OutputDeltaTime]
+        } else {
+            dict set energy_parameters_dict output_interval [write::getValue EnergyOptions OutputDeltaStep]
+        }
+        dict set energy_parameters_dict print_format [write::getValue EnergyOptions PrintFormat]
+
+        set output_file_settings_dict [dict create ]
+        dict set output_file_settings_dict output_path [write::getValue OutputFileSettings OutputPath]
+        dict set output_file_settings_dict file_name [write::getValue OutputFileSettings FileName]
+        dict set output_file_settings_dict file_extension [write::getValue OutputFileSettings FileExtension]
+        dict set energy_parameters_dict output_file_settings $output_file_settings_dict
+
+        dict set energy_dict Parameters $energy_parameters_dict
+        dict set output_process mpm_energy_output [list $energy_dict]
+    }
+
 
     return $output_process
 }

--- a/kratos.gid/apps/MPM/xml/Results.spd
+++ b/kratos.gid/apps/MPM/xml/Results.spd
@@ -49,6 +49,7 @@
 
         </container>
     </container>
+
     <container n="RestartOutput" pn="Restart-Output" un="RestartOutput" state="normal" open="1" open_window="0" icon="results">
         <value n="EnableRestartOutput" pn="Enable output" v="No" values="Yes,No" un="EnableRestartOutput" help="Writing output for Restart or not" />
         <container n="RestartOptions" pn="Options" un="RestartOptions" help="Restart postprocess options" open_window="1" icon="options" state="[checkStateByUniqueName EnableRestartOutput Yes]">
@@ -74,7 +75,7 @@
             <value n="OutputDeltaStep" pn="Time steps between outputs" v="1" help="Output will be printed in intervals of this number of steps" state="[getStateFromXPathValue {string(../value[@n='OutputControlType']/@v)} step]"/>
             <value n="PrintFormat" pn="Format" v=".8f" help="Format used for energy output values" />
             <container n="OutputFileSettings" pn="Output file settings" un="OutputFileSettings" open_window="1" icon="options">
-                <value n="OutputPath" pn="Output path" v="energy_output" help="Folder for energy output files" />
+                <value n="OutputPath" pn="Output path" v="" help="Folder for energy output files. Leave empty for current folder" />
                 <value n="FileName" pn="File name" v="MPM_Material_energy" help="Energy output file name" />
                 <value n="FileExtension" pn="File extension" v="dat" help="Energy output file extension" />
             </container>

--- a/kratos.gid/apps/MPM/xml/Results.spd
+++ b/kratos.gid/apps/MPM/xml/Results.spd
@@ -61,4 +61,24 @@
         </container>
     </container>
 
+    <container n="EnergyOutput" pn="Energy-Output" un="EnergyOutput" state="normal" open="1" open_window="0" icon="results">
+        <value n="EnableEnergyOutput" pn="Enable output" v="No" values="Yes,No" un="EnableEnergyOutput" help="Writing energy output for the selected MPM model part" >
+            <dependencies value="Off" node="../container[@n='EnergyOptions']" att1="state" v1="hidden"/>
+            <dependencies value="On" node="../container[@n='EnergyOptions']" att1="state" v1="normal"/>
+        </value>
+        <container n="EnergyOptions" pn="Options" un="EnergyOptions" help="MPM energy output options" open_window="1" icon="options" state="[checkStateByUniqueName EnableEnergyOutput Yes]">
+            <value n="OutputControlType" pn="Units used for output frequency" v="step" values="time,step" dict="time,Time (s),step,Steps" help="" update_proc="spdAux::RequestRefresh">
+                <dependencies node="../value" actualize="1"/>
+            </value>
+            <value n="OutputDeltaTime" pn="Time between outputs (s)" v="1.0" help="Output will be printed in intervals of this time" state="[getStateFromXPathValue {string(../value[@n='OutputControlType']/@v)} time]"/>
+            <value n="OutputDeltaStep" pn="Time steps between outputs" v="1" help="Output will be printed in intervals of this number of steps" state="[getStateFromXPathValue {string(../value[@n='OutputControlType']/@v)} step]"/>
+            <value n="PrintFormat" pn="Format" v=".8f" help="Format used for energy output values" />
+            <container n="OutputFileSettings" pn="Output file settings" un="OutputFileSettings" open_window="1" icon="options">
+                <value n="OutputPath" pn="Output path" v="energy_output" help="Folder for energy output files" />
+                <value n="FileName" pn="File name" v="MPM_Material_energy" help="Energy output file name" />
+                <value n="FileExtension" pn="File extension" v="dat" help="Energy output file extension" />
+            </container>
+        </container>
+    </container>
+
 </container>


### PR DESCRIPTION
Following the new process implemented by @ncrescenzio in https://github.com/KratosMultiphysics/Kratos/pull/14117, I think it could be a good idea to include this option in the GiD interface, following the corresponding documentation:
https://kratosmultiphysics.github.io/Kratos/pages/Applications/MPM_Application/Output_Processes/mpm_write_energy_output_process.html

The idea is to add this option to the *Results* section of the interface:

<img width="291" height="190" alt="Screenshot from 2026-05-15 09-53-28" src="https://github.com/user-attachments/assets/91d5afd2-5538-4bc0-814f-5606e97b6a92" />

and generate the following block in `ProjectParameters.json`:

<img width="601" height="274" alt="Screenshot from 2026-05-15 09-54-17" src="https://github.com/user-attachments/assets/e6feda55-8ffd-458c-8ba5-fcdbeb1bd9b0" />

Please feel free to suggest improvements or test the interface locally.
