### PR TITLE
[MPM] Fixing gravity bug

### DIFF
--- a/kratos.gid/apps/MPM/xml/Gravity.spd
+++ b/kratos.gid/apps/MPM/xml/Gravity.spd
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container n="Gravity" pn="Gravity" un="MPMGravity" help="" icon="gravity" open="1" open_window="0">
 	 <value n="ActivateGravity" pn="Activate Gravity" v="On" values="On,Off" un="ActivateGravity" help="">
-		  <dependencies value="On" node="../value[@n='modulus']" att1="v" v1='9.81'/>
-		  <dependencies value="On" node="../value[@n='direction']" att1="v" v1="0.0,-1.0,0.0"/>
 		  <dependencies value="On"  node="../value[@n='modulus']|../value[@n='direction']" att1="state" v1="normal"/>
 		  <dependencies value="Off" node="../value[@n='modulus']|../value[@n='direction']" att1="state" v1="hidden"/>
 	 </value>
-	 <value n="modulus" pn="Modulus" v="0.0" unit="m/s^2" unit_magnitude="Acceleration" help=""/>
-	 <value n="direction" pn="Direction" v="0.0,0.0,0.0" fieldtype="vector" help=""/>
+	 <value n="modulus" pn="Modulus" v="9.81" unit="m/s^2" unit_magnitude="Acceleration" help=""/>
+	 <value n="direction" pn="Direction" v="0.0,-1.0,0.0" fieldtype="vector" help=""/>
 </container>


### PR DESCRIPTION
There was a bug that did not allow users to modify the gravity direction and modulus from the GiD interface.

This has been fixed by removing the rules that overwrote the MPM gravity values whenever gravity was enabled. 
The default gravity values are now defined directly in the editable fields.

<img width="422" height="84" alt="Screenshot from 2026-05-19 15-27-55" src="https://github.com/user-attachments/assets/aaa58988-27ca-41bf-b424-7454e68987bc" />
