### PR TITLE
[MPM] Improvement "Results -> On nodes" output fields configuration

### DIFF
--- a/kratos.gid/apps/MPM/xml/Elements.xml
+++ b/kratos.gid/apps/MPM/xml/Elements.xml
@@ -23,9 +23,9 @@
       <parameter n="MATERIAL_POINTS_PER_ELEMENT" pn="Material points per element" type="combo" v="1" values="1,3,4,6,9,12,16,25" pvalues="1 (for triangles and quads),3 (for triangles),4 (for triangles and quads),6 (for triangles),9 (for quads),12 (for triangles),16 (for quads),25 (for quads)" help="Number of material points generated for each element. Available options are the following. Triangular: 1,3,4,6,12 and Quadrilateral: 1,4,9,16,25" />
     </inputs>
     <outputs>
+      <parameter n="MP_ACCELERATION" pn="Material point acceleration" v="false" />
       <parameter n="MP_VELOCITY" pn="Material point velocity" v="true" />
       <parameter n="MP_DISPLACEMENT" pn="Material point displacement" v="true" />
-      <parameter n="MP_ACCELERATION" pn="Material point acceleration" v="false" />
       <parameter n="MP_PRESSURE" pn="Material point pressure" v="false" state="hidden"/>
       <parameter n="MP_CAUCHY_STRESS_VECTOR" pn="Material point cauchy stress" v="false" />
       <parameter n="MP_EQUIVALENT_PLASTIC_STRAIN" pn="Material point equivalent plastic strain" v="false" />

--- a/kratos.gid/apps/MPM/xml/NodalConditions.xml
+++ b/kratos.gid/apps/MPM/xml/NodalConditions.xml
@@ -2,7 +2,7 @@
 <NodalConditionList>
   <NodalConditionItem n="ACCELERATION" pn="Acceleration" ProcessName="AssignVectorVariableProcess" VariableName="ACCELERATION" ImplementedInApplication="MPMApplication" analysis_type="Dynamic" unit_magnitude="Acceleration" units="m/s^2" v="No" App="MPM" Type="Output" state="CheckNodalConditionStateMPM" Interval="Total">
   </NodalConditionItem>
-  <NodalConditionItem n="VELOCITY" pn="Velocity" ProcessName="AssignInitialConditionToParticleProcess" VariableName="VELOCITY" ImplementedInApplication="MPMApplication" analysis_type="Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="MPM" Type="Initial" state="CheckNodalConditionStateMPM" Interval="Total">
+  <NodalConditionItem n="VELOCITY" pn="Velocity" ProcessName="AssignInitialConditionToParticleProcess" VariableName="VELOCITY" ImplementedInApplication="MPMApplication" analysis_type="Static,Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="MPM" Type="Initial" state="CheckNodalConditionStateMPM" Interval="Total">
   </NodalConditionItem>
   <NodalConditionItem n="DISPLACEMENT" pn="Displacement" ProcessName="AssignVectorVariableProcess" VariableName="DISPLACEMENT" ImplementedInApplication="StructuralMechanicsApplication"
 		      analysis_type="Static,Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="Structural" state="CheckNodalConditionStateStructural" Interval="Total">

--- a/kratos.gid/apps/MPM/xml/NodalConditions.xml
+++ b/kratos.gid/apps/MPM/xml/NodalConditions.xml
@@ -11,9 +11,5 @@
       <parameter n="PRESSURE" pn="Pressure" v="No"/>
     </outputs>
   </NodalConditionItem>
-
-
-
-
-
+  
 </NodalConditionList>

--- a/kratos.gid/apps/MPM/xml/NodalConditions.xml
+++ b/kratos.gid/apps/MPM/xml/NodalConditions.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <NodalConditionList>
+  <NodalConditionItem n="ACCELERATION" pn="Acceleration" ProcessName="AssignVectorVariableProcess" VariableName="ACCELERATION" ImplementedInApplication="MPMApplication" analysis_type="Dynamic" unit_magnitude="Acceleration" units="m/s^2" v="No" App="MPM" Type="Output" state="CheckNodalConditionStateMPM" Interval="Total">
+  </NodalConditionItem>
+  <NodalConditionItem n="VELOCITY" pn="Velocity" ProcessName="AssignInitialConditionToParticleProcess" VariableName="MP_VELOCITY" ImplementedInApplication="MPMApplication" analysis_type="Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="MPM" Type="Initial" state="CheckNodalConditionStateMPM" Interval="Total">
+  </NodalConditionItem>
   <NodalConditionItem n="DISPLACEMENT" pn="Displacement" ProcessName="AssignVectorVariableProcess" VariableName="DISPLACEMENT" ImplementedInApplication="StructuralMechanicsApplication"
 		      analysis_type="Static,Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="Structural" state="CheckNodalConditionStateStructural" Interval="Total">
     <outputs>
@@ -8,10 +12,8 @@
     </outputs>
   </NodalConditionItem>
 
-  <NodalConditionItem n="VELOCITY" pn="Velocity" ProcessName="AssignInitialConditionToParticleProcess" VariableName="MP_VELOCITY" ImplementedInApplication="MPMApplication" analysis_type="Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="MPM" Type="Initial" state="CheckNodalConditionStateMPM" Interval="Total">
-  </NodalConditionItem>
 
-  <NodalConditionItem n="ACCELERATION" pn="Acceleration" ProcessName="AssignVectorVariableProcess" VariableName="ACCELERATION" ImplementedInApplication="MPMApplication" analysis_type="Dynamic" unit_magnitude="Acceleration" units="m/s^2" v="No" App="MPM" Type="Output" state="CheckNodalConditionStateMPM" Interval="Total">
-  </NodalConditionItem>
+
+
 
 </NodalConditionList>

--- a/kratos.gid/apps/MPM/xml/NodalConditions.xml
+++ b/kratos.gid/apps/MPM/xml/NodalConditions.xml
@@ -3,8 +3,15 @@
   <NodalConditionItem n="DISPLACEMENT" pn="Displacement" ProcessName="AssignVectorVariableProcess" VariableName="DISPLACEMENT" ImplementedInApplication="StructuralMechanicsApplication"
 		      analysis_type="Static,Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="Structural" state="CheckNodalConditionStateStructural" Interval="Total">
     <outputs>
-      <parameter n="REACTION" pn="Reaction" v="Yes"/>
+      <parameter n="REACTION" pn="Reaction" v="No"/>
+      <parameter n="PRESSURE" pn="Pressure" v="No"/>
     </outputs>
   </NodalConditionItem>
-  
+
+  <NodalConditionItem n="VELOCITY" pn="Velocity" ProcessName="AssignInitialConditionToParticleProcess" VariableName="MP_VELOCITY" ImplementedInApplication="MPMApplication" analysis_type="Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="MPM" Type="Initial" state="CheckNodalConditionStateMPM" Interval="Total">
+  </NodalConditionItem>
+
+  <NodalConditionItem n="ACCELERATION" pn="Acceleration" ProcessName="AssignVectorVariableProcess" VariableName="ACCELERATION" ImplementedInApplication="MPMApplication" analysis_type="Dynamic" unit_magnitude="Acceleration" units="m/s^2" v="No" App="MPM" Type="Output" state="CheckNodalConditionStateMPM" Interval="Total">
+  </NodalConditionItem>
+
 </NodalConditionList>

--- a/kratos.gid/apps/MPM/xml/NodalConditions.xml
+++ b/kratos.gid/apps/MPM/xml/NodalConditions.xml
@@ -2,13 +2,13 @@
 <NodalConditionList>
   <NodalConditionItem n="ACCELERATION" pn="Acceleration" ProcessName="AssignVectorVariableProcess" VariableName="ACCELERATION" ImplementedInApplication="MPMApplication" analysis_type="Dynamic" unit_magnitude="Acceleration" units="m/s^2" v="No" App="MPM" Type="Output" state="CheckNodalConditionStateMPM" Interval="Total">
   </NodalConditionItem>
-  <NodalConditionItem n="VELOCITY" pn="Velocity" ProcessName="AssignInitialConditionToParticleProcess" VariableName="MP_VELOCITY" ImplementedInApplication="MPMApplication" analysis_type="Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="MPM" Type="Initial" state="CheckNodalConditionStateMPM" Interval="Total">
+  <NodalConditionItem n="VELOCITY" pn="Velocity" ProcessName="AssignInitialConditionToParticleProcess" VariableName="VELOCITY" ImplementedInApplication="MPMApplication" analysis_type="Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="MPM" Type="Initial" state="CheckNodalConditionStateMPM" Interval="Total">
   </NodalConditionItem>
   <NodalConditionItem n="DISPLACEMENT" pn="Displacement" ProcessName="AssignVectorVariableProcess" VariableName="DISPLACEMENT" ImplementedInApplication="StructuralMechanicsApplication"
 		      analysis_type="Static,Quasi-static,Dynamic"  unit_magnitude="L" units="m" App="Structural" state="CheckNodalConditionStateStructural" Interval="Total">
     <outputs>
-      <parameter n="REACTION" pn="Reaction" v="No"/>
       <parameter n="PRESSURE" pn="Pressure" v="No"/>
+      <parameter n="REACTION" pn="Reaction" v="No"/>
     </outputs>
   </NodalConditionItem>
   

--- a/kratos.gid/apps/MPM/xml/Procs.spd
+++ b/kratos.gid/apps/MPM/xml/Procs.spd
@@ -5,6 +5,12 @@
 	  <![CDATA[
 	  return [Structural::xml::ProcCheckNodalConditionStateStructural $domNode $args]
 	  ]]>
+	</proc>
+
+    <proc n='CheckNodalConditionStateMPM' args='args'>
+	  <![CDATA[
+	  return [MPM::xml::ProcCheckNodalConditionStateMPM $domNode $args]
+	  ]]>
 	</proc>		
 	
 	<proc n='CheckGeometrySolid' args='args'>
@@ -33,6 +39,18 @@
 	<proc n='CheckStabilizationState' args='args'>
 	  <![CDATA[
 	  return [MPM::xml::ProcCheckStabilizationState $domNode $args]
+	  ]]>
+	</proc>
+
+	<proc n='CheckNodalConditionOutputState' args='args'>
+	  <![CDATA[
+	  return [MPM::xml::ProcCheckNodalConditionOutputState $domNode $args]
+	  ]]>
+	</proc>
+
+	<proc n='CheckNodalConditionOutputStateMPM' args='args'>
+	  <![CDATA[
+	  return [MPM::xml::ProcCheckNodalConditionOutputState $domNode $args]
 	  ]]>
 	</proc>
 

--- a/kratos.gid/apps/MPM/xml/Procs.spd
+++ b/kratos.gid/apps/MPM/xml/Procs.spd
@@ -54,4 +54,10 @@
 	  ]]>
 	</proc>
 
+	<proc n='ElementOutputState' args='args'>
+	  <![CDATA[
+	  return [MPM::xml::ProcElementOutputState $domNode $args]
+	  ]]>
+	</proc>
+
 </container>

--- a/kratos.gid/apps/MPM/xml/XmlController.tcl
+++ b/kratos.gid/apps/MPM/xml/XmlController.tcl
@@ -159,3 +159,16 @@ proc MPM::xml::ProcCheckNodalConditionOutputState {domNode args} {
 
     return [MPM::xml::CheckNodalConditionStateById $conditionId $domNode]
 }
+
+proc MPM::xml::ProcElementOutputState {domNode args} {
+    set outputId [$domNode @n]
+    if {$outputId eq "MP_PRESSURE"} {
+        if {[MPM::xml::UsesMixedUPElements]} {
+            $domNode setAttribute v Yes
+            return "normal"
+        }
+        return "hidden"
+    }
+
+    return [spdAux::ProcElementOutputState $domNode $args]
+}

--- a/kratos.gid/apps/MPM/xml/XmlController.tcl
+++ b/kratos.gid/apps/MPM/xml/XmlController.tcl
@@ -58,11 +58,48 @@ proc MPM::xml::getUniqueName {name} {
     return MPM${name}
 }
 
+proc ::MPM::xml::ProcCheckNodalConditionStateMPM {domNode args} {
+    return [MPM::xml::CheckNodalConditionStateById [$domNode @n] $domNode]
+}
+
+proc MPM::xml::CheckNodalConditionStateById {conditionId domNode} {
+    set parts_un STParts
+    if {[spdAux::getRoute $parts_un] ne ""} {
+        set condition [Model::getNodalConditionbyId $conditionId]
+        set cnd_dim [$condition getAttribute WorkingSpaceDimension]
+        if {$cnd_dim ne "" && $cnd_dim ne $Model::SpatialDimension} {
+            return "hidden"
+        }
+        set elems [$domNode selectNodes "[spdAux::getRoute $parts_un]/condition/group/value\[@n='Element'\]"]
+        set elemnames [list]
+        foreach elem $elems {
+            lappend elemnames [$elem @v]
+        }
+        set elemnames [lsort -unique $elemnames]
+
+        set solutionType [get_domnode_attribute [$domNode selectNodes [spdAux::getRoute STSoluType]] v]
+        set params [list analysis_type $solutionType]
+        if {[::Model::CheckElementsNodalCondition $conditionId $elemnames $params]} {
+            return "normal"
+        }
+        return "hidden"
+    }
+    return "normal"
+}
+
 proc MPM::xml::CustomTree { args } {
 
 #     spdAux::SetValueOnTreeItem v "time" Results OutputControlType
 #     spdAux::SetValueOnTreeItem values "time" Results OutputControlType
     spdAux::SetValueOnTreeItem v No NodalResults PARTITION_INDEX
+    spdAux::SetValueOnTreeItem v No NodalResults REACTION
+    spdAux::SetValueOnTreeItem state {[CheckNodalConditionOutputStateMPM DISPLACEMENT]} NodalResults REACTION
+    if {[MPM::xml::UsesMixedUPElements]} {
+        spdAux::SetValueOnTreeItem v Yes NodalResults PRESSURE
+    } else {
+        spdAux::SetValueOnTreeItem v No NodalResults PRESSURE
+    }
+    spdAux::SetValueOnTreeItem state {[CheckNodalConditionOutputStateMPM DISPLACEMENT]} NodalResults PRESSURE
     spdAux::SetValueOnTreeItem v "LinearSolversApplication.sparse_lu" MPMimplicitlinear_solver_settings Solver
 }
 
@@ -93,4 +130,32 @@ proc MPM::xml::ProcCheckStabilizationState {domNode args} {
         if {$second_check eq "On"} {set ret "normal"}
     }
     return $ret
+}
+
+proc MPM::xml::UsesMixedUPElements { } {
+    foreach elem [::MPM::write::GetUsedElements Name] {
+        if {$elem in [list MPMUpdatedLagrangianUP2D MPMUpdatedLagrangianUP3D]} {
+            return 1
+        }
+    }
+    return 0
+}
+
+proc MPM::xml::ProcCheckNodalConditionOutputState {domNode args} {
+    set conditionId [lindex $args 0]
+    set outputId [$domNode @n]
+
+    if {![::Model::CheckNodalConditionOutputState $conditionId $outputId]} {
+        return "hidden"
+    }
+
+    if {$outputId eq "PRESSURE"} {
+        if {[MPM::xml::UsesMixedUPElements]} {
+            $domNode setAttribute v Yes
+            return "normal"
+        }
+        return "hidden"
+    }
+
+    return [MPM::xml::CheckNodalConditionStateById $conditionId $domNode]
 }


### PR DESCRIPTION
### Changes

- Adds missing nodal result fields in `Results > On nodes`:
  - `ACCELERATION` 
  - `VELOCITY`
  - `PRESSURE`

- Shows and enables `PRESSURE` by default only when a mixed UP  formulation is used.
- The pressure result options are hidden for non-mixed formulations to avoid exposing unavailable output fields.
- Applies the same mixed-formulation visibility logic to `MP_PRESSURE` in `Results > On element`.

<img width="287" height="112" alt="image" src="https://github.com/user-attachments/assets/89ff61f0-6e5c-4ce0-bf76-cae317c1bfc2" />


I would appreciate it if you could try this locally, in case I missed anything. Suggestions for improvement are also very welcome.