### PR TITLE
[MPM] Friction option added to slip condition

### DIFF
--- a/kratos.gid/apps/MPM/write/writeProjectParameters.tcl
+++ b/kratos.gid/apps/MPM/write/writeProjectParameters.tcl
@@ -78,6 +78,7 @@ proc ::MPM::write::getParametersDict { } {
     set load_process_list [dict get $project_parameters_dict processes loads_process_list]
     foreach load $load_process_list {
         if {[dict get $load python_module] eq "apply_mpm_slip_boundary_process"} {
+            set load [MPM::write::CleanSlipBoundaryProcess $load]
             lappend slip_process_list $load
         } else {
             lappend new_load_process_list $load
@@ -327,5 +328,32 @@ proc ::MPM::write::writeParametersEvent { } {
     write::WriteJSON [getParametersDict]
 }
 
+proc ::MPM::write::CleanSlipBoundaryProcess { slip_process_dict } {
+    if {![dict exists $slip_process_dict Parameters]} {
+        return $slip_process_dict
+    }
 
+    set friction "Off"
+    if {[dict exists $slip_process_dict Parameters Friction]} {
+        set friction [dict get $slip_process_dict Parameters Friction]
+        dict unset slip_process_dict Parameters Friction
+    }
 
+    if {$friction ne "On"} {
+        foreach parameter_name [list friction_coefficient tangential_penalty_factor option] {
+            if {[dict exists $slip_process_dict Parameters $parameter_name]} {
+                dict unset slip_process_dict Parameters $parameter_name
+            }
+        }
+        return $slip_process_dict
+    }
+
+    if {[dict exists $slip_process_dict Parameters option]} {
+        set option [dict get $slip_process_dict Parameters option]
+        if {$option eq "" || $option eq "none"} {
+            dict unset slip_process_dict Parameters option
+        }
+    }
+
+    return $slip_process_dict
+}

--- a/kratos.gid/apps/MPM/xml/Processes.xml
+++ b/kratos.gid/apps/MPM/xml/Processes.xml
@@ -11,8 +11,12 @@
   <Process n="ApplyMPMSlipBoundaryProcess" pn="ApplyMPMSlipBoundaryProcess" python_module="apply_mpm_slip_boundary_process"
 	   kratos_module="KratosMultiphysics.MPMApplication" help="" >
     <inputs>
+      <parameter n="Friction" pn="Friction" type="combo" v="Off" values="Off,On" help="Activate friction for the slip boundary condition">
+        <parameter parent="On" n="friction_coefficient" pn="Friction coefficient" type="double" v="0.001" />
+        <parameter parent="On" n="tangential_penalty_factor" pn="Tangential penalty factor" type="double" v="1e6" />
+        <parameter parent="On" n="option" pn="Normal option" type="combo" v="flip_normal" values="none,flip_normal" pvalues="None,Flip normal" />
+      </parameter>
     </inputs>
   </Process>
 
  </ProcessList>
-


### PR DESCRIPTION
Added a Friction penalty option to the usual slip conforming boundary condition:
<img width="481" height="121" alt="Screenshot from 2026-05-26 15-32-38" src="https://github.com/user-attachments/assets/6520a362-2490-441c-a689-e47a91de49ff" />

- By default Friction is off.
- The current `writeprojectparameters.tcl` writes:

```
{
            "python_module" : "apply_mpm_slip_boundary_process",
            "kratos_module" : "KratosMultiphysics.MPMApplication",
            "process_name"  : "ApplyMPMSlipBoundaryProcess",
            "Parameters"    : {
                "model_part_name"           : "Background_Grid.Slip_Auto1",
                "friction_coefficient"      : 0.001,
                "tangential_penalty_factor" : 1000000.0,
                "option"                    : "flip_normal"
            }
        }
```

- Added a cleanup step in  `writeprojectparameters.tcl` for the MPM slip boundary process to remove friction controls from the generated ProjectParameters. 
- When friction is disabled, the slip process is written as before.