### PR TITLE
<MaximumGiDVersion> of kratos.xml optional, and must be set only once…

### DIFF
--- a/kratos.gid/scripts/Utils.tcl
+++ b/kratos.gid/scripts/Utils.tcl
@@ -90,7 +90,7 @@ proc Kratos::WarnAboutMinimumRecommendedGiDVersion { } {
         W "Download it from: https://www.gidsimulation.com/gid-for-science/downloads/"
     }
     # Check GiD maximum version
-    if { [GidUtils::VersionCmp $kratos_private(MaximumGiDVersion)] > 0 } {
+    if { [info exists kratos_private(MaximumGiDVersion)] && [GidUtils::VersionCmp $kratos_private(MaximumGiDVersion)] > 0 } {
         W "Warning: kratos interface requires GiD $kratos_private(MaximumGiDVersion) or less."
         W "You may experience problems with the python packages"
         W "You can download it from: https://www.gidsimulation.com/gid-for-science/downloads/"


### PR DESCRIPTION
<MaximumGiDVersion> of kratos.xml optional, and must be set only once is known that a version break the back compatiblity with this kratos version (by default assume that is not break)